### PR TITLE
Feature/instructor regist

### DIFF
--- a/src/main/java/com/wanted/cookielms/domain/lecture/controller/InstructorController.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/controller/InstructorController.java
@@ -1,0 +1,76 @@
+package com.wanted.cookielms.domain.lecture.controller;
+
+import com.wanted.cookielms.domain.lecture.dto.LectureInsDTO;
+import com.wanted.cookielms.domain.lecture.dto.LectureStuDTO;
+import com.wanted.cookielms.domain.lecture.service.InstructorService;
+import com.wanted.cookielms.domain.lecture.service.LectureStuService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.io.IOException;
+
+/**
+ * [규칙 6] 강사 관련 요청 처리 전용 컨트롤러
+ */
+@Slf4j
+@Controller
+@RequestMapping("/instructor")
+@RequiredArgsConstructor
+public class InstructorController {
+
+    private final InstructorService instructorService;
+    private final LectureStuService lectureStuService;
+
+    @GetMapping("/lecture/detail/{id}")
+    public String lectureDetail(@PathVariable("id") Long id, Model model) {
+        // 친구가 만든 서비스 로직을 사용하여 데이터를 가져옵니다.
+        // 이때 DB의 'lecture' 테이블에서 id로 데이터를 한 건 조회합니다.
+        LectureStuDTO lecture = lectureStuService.getLectureDetail(id);
+
+        // 친구의 HTML(lecture_detail.html)에서 사용할 수 있도록 모델에 담습니다.
+        model.addAttribute("lecture", lecture);
+
+        // 친구가 만든 상세 페이지 HTML 경로로 연결합니다.
+        return "role/student/lecture_detail";
+    }
+    /**
+     * 강의 등록 페이지 이동
+     */
+    @GetMapping("/lecture/regist")
+    public String registPage() {
+        return "role/instructor/lecture_regist"; // templates/lectureRegist.html과 매핑
+    }
+
+    /**
+     * 강의 등록 실행
+     * [이미지 예시 스타일] 파라미터에서 DTO를 직접 선언하여 수신
+     */
+    @PostMapping("/lecture/regist")
+    public String registLecture(LectureInsDTO lectureInsDTO, RedirectAttributes redirectAttributes) {
+        try {
+            instructorService.registLecture(lectureInsDTO);
+            log.info("✅ 강의 등록 성공: {}", lectureInsDTO.getTitle());
+            // 성공 시 FlashAttribute 사용
+            redirectAttributes.addFlashAttribute("message", "✅ 강의 등록이 완료되었습니다!");
+            return "redirect:/instructor/lecture/regist?status=success";
+
+        } catch (IllegalArgumentException e) {
+            // [수정] 서비스에서 던진 메시지("5MB를 초과합니다...")를 그대로 전달
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+            return "redirect:/instructor/lecture/regist";
+
+        } catch (IOException e) {
+            log.error("❌ 파일 저장 에러", e);
+            redirectAttributes.addFlashAttribute("errorMessage", "파일 저장 중 오류가 발생했습니다.");
+            return "redirect:/instructor/lecture/regist";
+        }
+
+    }
+}

--- a/src/main/java/com/wanted/cookielms/domain/lecture/controller/InstructorController.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/controller/InstructorController.java
@@ -30,14 +30,14 @@ public class InstructorController {
 
     @GetMapping("/lecture/detail/{id}")
     public String lectureDetail(@PathVariable("id") Long id, Model model) {
-        // 친구가 만든 서비스 로직을 사용하여 데이터를 가져옵니다.
+
         // 이때 DB의 'lecture' 테이블에서 id로 데이터를 한 건 조회합니다.
         LectureStuDTO lecture = lectureStuService.getLectureDetail(id);
 
         // 친구의 HTML(lecture_detail.html)에서 사용할 수 있도록 모델에 담습니다.
         model.addAttribute("lecture", lecture);
 
-        // 친구가 만든 상세 페이지 HTML 경로로 연결합니다.
+
         return "role/student/lecture_detail";
     }
     /**
@@ -62,7 +62,7 @@ public class InstructorController {
             return "redirect:/instructor/lecture/regist?status=success";
 
         } catch (IllegalArgumentException e) {
-            // [수정] 서비스에서 던진 메시지("5MB를 초과합니다...")를 그대로 전달
+            // 서비스에서 던진 메시지("5MB를 초과합니다..."
             redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
             return "redirect:/instructor/lecture/regist";
 

--- a/src/main/java/com/wanted/cookielms/domain/lecture/dto/LectureInsDTO.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/dto/LectureInsDTO.java
@@ -1,0 +1,26 @@
+package com.wanted.cookielms.domain.lecture.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.ToString;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class LectureInsDTO {
+
+    private String title;           // 강의 제목
+    private String description;     // 강의 설명
+    private MultipartFile lectureFile;
+    private String videoUrl;// 수업 자료 (HTML의 name="lectureFile"와 매칭)
+
+    private Integer maxCapacity;
+    private String lectureDay;
+    private String startTime;
+    private String endTime;
+}

--- a/src/main/java/com/wanted/cookielms/domain/lecture/entity/InsLecture.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/entity/InsLecture.java
@@ -58,12 +58,12 @@ public class InsLecture {
         this.description = description;
         this.videoUrl = videoUrl;
         this.fileSavedName = fileSavedName;
-        // 👇 빌더 파라미터로 받은 값들 저장
+
         this.maxCapacity = maxCapacity;
         this.lectureDay = lectureDay;
         this.startTime = startTime;
         this.endTime = endTime;
-        // 👇 기본값 설정
+        //  기본값 설정
         this.currentEnrollment = 0;
         this.status = "OPEN";
         this.instructorId = 2L;

--- a/src/main/java/com/wanted/cookielms/domain/lecture/entity/InsLecture.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/entity/InsLecture.java
@@ -1,0 +1,71 @@
+package com.wanted.cookielms.domain.lecture.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@Table(name = "lecture")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InsLecture {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "lecture_id")
+    private Long id;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "video_url")
+    private String videoUrl;
+
+    @Column(name = "material_id") // 친구 컬럼명과 매핑
+    private String fileSavedName;
+
+    // ⭐ [여기서부터 추가된 필드들입니다!] ⭐
+    @Column(name = "max_capacity")
+    private Integer maxCapacity;
+
+    @Column(name = "current_enrollment")
+    private Integer currentEnrollment = 0; // 등록 시 기본값 0
+
+    @Column(length = 20)
+    private String status = "OPEN"; // 등록 시 기본값 OPEN
+
+    @Column(name = "lecture_day")
+    private String lectureDay;
+
+    @Column(name = "start_time")
+    private LocalTime startTime;
+
+    @Column(name = "end_time")
+    private LocalTime endTime;
+
+    @Column(name = "user_id")
+    private Long instructorId = 2L; // 친구 테스트용 강사 ID 고정
+
+    @Builder
+    private InsLecture(String title, String description, String videoUrl, String fileSavedName,
+                       Integer maxCapacity, String lectureDay, LocalTime startTime, LocalTime endTime) {
+        this.title = title;
+        this.description = description;
+        this.videoUrl = videoUrl;
+        this.fileSavedName = fileSavedName;
+        // 👇 빌더 파라미터로 받은 값들 저장
+        this.maxCapacity = maxCapacity;
+        this.lectureDay = lectureDay;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        // 👇 기본값 설정
+        this.currentEnrollment = 0;
+        this.status = "OPEN";
+        this.instructorId = 2L;
+    }
+}

--- a/src/main/java/com/wanted/cookielms/domain/lecture/repository/LectureInsRepository.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/repository/LectureInsRepository.java
@@ -1,0 +1,10 @@
+package com.wanted.cookielms.domain.lecture.repository;
+
+import com.wanted.cookielms.domain.lecture.entity.InsLecture;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class LectureInsRepository {
+    public void save(InsLecture lecture) {
+    }
+}

--- a/src/main/java/com/wanted/cookielms/domain/lecture/repository/LectureInsRepository.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/repository/LectureInsRepository.java
@@ -1,10 +1,10 @@
 package com.wanted.cookielms.domain.lecture.repository;
 
 import com.wanted.cookielms.domain.lecture.entity.InsLecture;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class LectureInsRepository {
-    public void save(InsLecture lecture) {
+public interface LectureInsRepository extends JpaRepository<InsLecture, Long>{
+
     }
-}

--- a/src/main/java/com/wanted/cookielms/domain/lecture/service/InstructorService.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/service/InstructorService.java
@@ -1,0 +1,78 @@
+package com.wanted.cookielms.domain.lecture.service;
+
+import com.wanted.cookielms.domain.lecture.dto.LectureInsDTO;
+import com.wanted.cookielms.domain.lecture.entity.InsLecture;
+import com.wanted.cookielms.domain.lecture.repository.LectureInsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InstructorService {
+
+    private final LectureInsRepository lectureInsRepository;
+    private final String uploadPath = "C:/cookielms/uploads/";
+
+    @Transactional
+    public void registLecture(LectureInsDTO dto) throws IOException {
+
+        // 1. 파일 저장 (PDF 검증 포함)
+        String fileSavedName = saveFile(dto.getLectureFile());
+
+        // 2. 엔티티 생성 (하드코딩 없이 DTO에서 직접 꺼내기)
+        InsLecture lecture = InsLecture.builder()
+                .title(dto.getTitle())
+                .description(dto.getDescription())
+                .videoUrl(dto.getVideoUrl())
+                .fileSavedName(fileSavedName)
+                // 👇 HTML에서 넘겨준 세부 설정 데이터 매핑
+                .maxCapacity(dto.getMaxCapacity())
+                .lectureDay(dto.getLectureDay())
+                .startTime(LocalTime.parse(dto.getStartTime())) // "09:00" 문자열 -> LocalTime 변환
+                .endTime(LocalTime.parse(dto.getEndTime()))     // "10:00" 문자열 -> LocalTime 변환
+                .build();
+
+        // 3. DB 저장
+        lectureInsRepository.save(lecture);
+    }
+
+    /**
+     * 파일 저장 로직 (PDF 형식 및 5MB 용량 체크)
+     */
+    private String saveFile(MultipartFile file) throws IOException {
+        if (file == null || file.isEmpty()) return null;
+
+        String originalName = file.getOriginalFilename();
+
+        // 1. 확장자 체크
+        if (originalName == null || !originalName.toLowerCase().endsWith(".pdf")) {
+            throw new IllegalArgumentException("맞지 않는 형식의 파일입니다. PDF만 업로드 해주세요.");
+        }
+
+        // 2. 용량 체크 (5MB)
+        long maxSize = 5 * 1024 * 1024;
+        if (file.getSize() > maxSize) {
+            throw new IllegalArgumentException("5MB를 초과합니다. 5MB 이하의 PDF를 업로드 해주세요.");
+        }
+
+        // 3. 실제 폴더에 저장
+        String ext = originalName.substring(originalName.lastIndexOf("."));
+        String savedName = UUID.randomUUID().toString() + ext;
+        File target = new File(uploadPath, savedName);
+
+        if (!target.getParentFile().exists()) {
+            target.getParentFile().mkdirs();
+        }
+        file.transferTo(target);
+
+        return savedName;
+    }
+}

--- a/src/main/java/com/wanted/cookielms/global/WebConfig.java
+++ b/src/main/java/com/wanted/cookielms/global/WebConfig.java
@@ -1,0 +1,16 @@
+package com.wanted.cookielms.global;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        // [추가] 브라우저가 /uploads/파일명 으로 요청하면 C:/cookielms/uploads/ 폴더에서 파일을 찾아줌
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations("file:///C:/cookielms/uploads/");
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,16 +1,32 @@
 spring:
+  # 데이터베이스 연결 설정
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    # 'coookie'에서 'CoookieLMS'로 변경
     url: jdbc:mysql://localhost:3306/CoookieLMS
     username: cookie
     password: cookie
+
+  # JPA 및 하이버네이트 설정
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true # JPA가 생성하는 SQL을 콘솔에 출력
+    show-sql: true # SQL 콘솔 출력
     properties:
       hibernate:
-        format_sql: true # SQL을 보기 좋게 정렬
-        highlight_sql: true # (선택) SQL 키워드에 색상 부여
+        format_sql: true # SQL 정렬
+        highlight_sql: true # SQL 키워드 강조
+        dialect: org.hibernate.dialect.MySQLDialect # MySQL 방언 명시
 
+  # [추가] 파일 업로드 용량 제한 설정
+  # 유튜브 링크 방식을 사용하므로 영상 용량은 필요 없지만,
+  # PDF 등 수업 자료 업로드를 안전하게 제한하기 위해 설정합니다.
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 10MB
+
+# 로그 레벨 설정 (디버깅용)
+logging:
+  level:
+    org.hibernate.SQL: debug

--- a/src/main/resources/templates/role/instructor/lecture_regist.html
+++ b/src/main/resources/templates/role/instructor/lecture_regist.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>강의 등록</title>
+  <style>
+    body { font-family: 'Malgun Gothic', sans-serif; padding: 20px; background-color: #f4f7f6; color: #333; }
+    .container { max-width: 600px; margin: auto; background: white; padding: 30px; border-radius: 12px; box-shadow: 0 4px 15px rgba(0,0,0,0.1); }
+    h2 { border-bottom: 2px solid #007bff; padding-bottom: 10px; margin-bottom: 25px; color: #007bff; }
+    div { margin-bottom: 20px; }
+    label { display: block; margin-bottom: 8px; font-weight: bold; }
+    input[type="text"], textarea { width: 100%; padding: 10px; box-sizing: border-box; border: 1px solid #ccc; border-radius: 4px; }
+    textarea { height: 100px; resize: none; }
+    button { width: 100%; padding: 12px; background-color: #007bff; color: white; border: none; cursor: pointer; border-radius: 6px; font-size: 16px; font-weight: bold; }
+    button:hover { background-color: #0056b3; }
+  </style>
+</head>
+<body>
+<div class="container">
+  <h2>강의 등록 (강사용)</h2>
+
+  <form th:action="@{/instructor/lecture/regist}" method="post" enctype="multipart/form-data">
+    <div><label>강의 제목:</label><input type="text" name="title" required placeholder="강의 제목을 입력하세요"></div>
+    <div><label>강의 설명:</label><textarea name="description" required placeholder="강의 상세 설명"></textarea></div>
+    <div><label>유튜브 영상 주소:</label><input type="text" name="videoUrl" placeholder="https://..." required autocomplete="off"></div>
+    <div>
+      <div style="padding: 20px; background: #FFEB3B; border: 3px dashed #F44336; border-radius: 12px; margin: 20px 0;">
+        <h3 style="margin-top: 0; color: #d32f2f;">⭐ 강의 세부 설정 (꼭 입력!) ⭐</h3>
+
+        <div style="display: flex; gap: 15px; margin-bottom: 15px;">
+          <div style="flex: 1;">
+            <label style="color: #333;">👥 최대 인원</label>
+            <input type="number" name="maxCapacity" value="30" required style="width: 100%; height: 40px; font-size: 16px;">
+          </div>
+          <div style="flex: 1;">
+            <label style="color: #333;">📅 강의 요일</label>
+            <input type="text" name="lectureDay" placeholder="예: 월요일" required style="width: 100%; height: 40px; font-size: 16px;">
+          </div>
+        </div>
+
+        <div style="display: flex; gap: 15px;">
+          <div style="flex: 1;">
+            <label style="color: #333;">⏰ 시작 시간</label>
+            <input type="time" name="startTime" required style="width: 100%; height: 40px; font-size: 16px;">
+          </div>
+          <div style="flex: 1;">
+            <label style="color: #333;">⌛ 종료 시간</label>
+            <input type="time" name="endTime" required style="width: 100%; height: 40px; font-size: 16px;">
+          </div>
+        </div>
+      </div>
+      <label>수업 자료 (PDF만 가능, 최대 5MB):</label>
+      <input type="file" name="lectureFile" id="lectureFile" required onchange="validateFile(this)">
+    </div>
+    <div style="margin-top: 30px;"><button type="submit">등록하기</button></div>
+  </form>
+</div>
+
+<script th:inline="javascript">
+  function validateFile(input) {
+    // [수정] input.files으로 정확히 파일을 가져옵니다.
+    const file = input.files;
+    if (!file) return;
+
+    // A. 확장자 체크
+    const fileName = file.name;
+    const fileExtension = fileName.split('.').pop().toLowerCase();
+
+    if (fileExtension !== 'pdf') {
+      alert("❌ 맞지 않는 형식의 파일입니다. PDF만 업로드 해주세요.");
+      resetFile(input);
+      return;
+    }
+
+    // B. 용량 체크 (5MB)
+    const maxSize = 5 * 1024 * 1024;
+
+    // [수정] file.getSize()는 없습니다. file.size가 정답입니다.
+    if (file.size > maxSize) {
+      alert("❌ 5MB를 초과합니다. 5MB 이하의 PDF를 업로드 해주세요.");
+      resetFile(input);
+      return;
+    }
+  }
+
+  function resetFile(input) {
+    input.value = "";
+    if (input.value) {
+      input.type = "text";
+      input.type = "file";
+    }
+  }
+
+  /*<![CDATA[*/
+  // 서버에서 보낸 에러 메시지 팝업 처리
+  const errorMsg = /*[[${errorMessage}]]*/ null;
+  if (errorMsg) {
+    alert("❌ " + errorMsg);
+  }
+
+  const successMsg = /*[[${message}]]*/ null;
+  if (successMsg) {
+    alert(successMsg);
+  }
+  /*]]>*/
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #14

---

## 📝 작업한 내용
<!-- 이번 PR에서 변경한 내용을 간략하게 설명해주세요 -->
-하연 코드 규격에 맞춰 DB/엔티티 수정  상세 페이지 연동을 위해 테이블명을 lecture로 바꾸고, 인원·요일·시간 필드를 추가했습니다.

-강의 등록 로직 "진짜" 데이터 연결 기존의 하드코딩(가짜 데이터)을 제거하고, 사용자가 입력한 값이 DB에 저장되도록 수정했습니다.(일부)

---

## 🖥️ 구현한 내용 시연 방법
<!-- 리뷰어가 직접 확인할 수 있도록 실행 방법 또는 테스트 절차를 작성해주세요 -->

1. http://localhost:8080/instructor/lecture/regist 등록 페이지 
2. DB 확인: MySQL Workbench에서 SELECT * FROM lecture ORDER BY lecture_id DESC;
3. http://localhost:8080/instructor/lecture/detail/{방금_생성된_ID}

---

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했습니다
- [x] 불필요한 주석 및 콘솔 로그를 제거했습니다
- [x] 관련 이슈와 연결했습니다
