### PR TITLE
[Feat] 강사 강의 수정 기능 구현 

### DIFF
--- a/src/main/java/com/wanted/cookielms/domain/lecture/controller/InstructorController.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/controller/InstructorController.java
@@ -12,10 +12,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.io.IOException;
@@ -67,7 +64,9 @@ public class InstructorController {
      * 강의 등록 페이지 이동
      */
     @GetMapping("/lecture/regist")
-    public String registPage() {
+    public String registPage(Model model) {
+        model.addAttribute("lecture", new LectureInsDTO()); // 빈 바구니를 넣어줘야 에러가 안 납니다!
+        model.addAttribute("isEdit", false);
         return "role/instructor/lecture_regist"; // templates/lectureRegist.html과 매핑
     }
 
@@ -101,6 +100,39 @@ public class InstructorController {
            return "redirect:/instructor/lectures?instructorId=1";
         }
 
+
     }
 
+
+    /**
+     * 1. 수정 페이지로 이동 (GET)
+     */
+    @GetMapping("/lecture/edit/{id}")
+    public String inseditPage(@PathVariable("id") Long id, Model model) {
+        // 기존 상세조회 로직을 활용해 데이터를 가져옵니다.
+        LectureInsDTO lecture = instructorService.getLectureForEdit(id);
+
+        model.addAttribute("lecture", lecture);
+        model.addAttribute("isEdit", true); // 이 값이 true면 HTML에서 '수정' 모드로 작동합니다.
+        return "role/instructor/lecture_regist"; // 기존 등록 페이지를 그대로 사용합니다!
+    }
+
+    /**
+     * 2. 수정 실행 (POST)
+     */
+    @PostMapping("/lecture/edit/{id}")
+    public String updateLecture(
+            @PathVariable("id") Long id,
+            @ModelAttribute LectureInsDTO lectureInsDTO,
+            RedirectAttributes redirectAttributes) {
+        try {
+            instructorService.updateLecture(id, lectureInsDTO);
+            redirectAttributes.addFlashAttribute("message", "✅ 강의 수정이 완료되었습니다!");
+            return "redirect:/instructor/lecture/detail/" + id;
+        } catch (Exception e) {
+            log.error("❌ 수정 중 오류 발생: ", e);
+            redirectAttributes.addFlashAttribute("errorMessage", "수정 중 오류가 발생했습니다.");
+            return "redirect:/instructor/lecture/edit/" + id;
+        }
+    }
 }

--- a/src/main/java/com/wanted/cookielms/domain/lecture/controller/InstructorController.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/controller/InstructorController.java
@@ -109,12 +109,12 @@ public class InstructorController {
      */
     @GetMapping("/lecture/edit/{id}")
     public String inseditPage(@PathVariable("id") Long id, Model model) {
-        // 기존 상세조회 로직을 활용해 데이터를 가져옵니다.
+
         LectureInsDTO lecture = instructorService.getLectureForEdit(id);
 
         model.addAttribute("lecture", lecture);
-        model.addAttribute("isEdit", true); // 이 값이 true면 HTML에서 '수정' 모드로 작동합니다.
-        return "role/instructor/lecture_regist"; // 기존 등록 페이지를 그대로 사용합니다!
+        model.addAttribute("isEdit", true);
+        return "role/instructor/lecture_regist";
     }
 
     /**

--- a/src/main/java/com/wanted/cookielms/domain/lecture/dto/LectureInsDTO.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/dto/LectureInsDTO.java
@@ -14,13 +14,14 @@ import org.springframework.web.multipart.MultipartFile;
 @ToString
 public class LectureInsDTO {
 
-    private String title;           // 강의 제목
-    private String description;     // 강의 설명
+    private Long lectureId;
+    private String title;
+    private String description;
     private MultipartFile lectureFile;
-    private String videoUrl;// 수업 자료 (HTML의 name="lectureFile"와 매칭)
-
+    private String videoUrl;
     private Integer maxCapacity;
     private String lectureDay;
     private String startTime;
     private String endTime;
+
 }

--- a/src/main/java/com/wanted/cookielms/domain/lecture/entity/InsLecture.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/entity/InsLecture.java
@@ -29,6 +29,9 @@ public class InsLecture {
     @Column(name = "material_id") // 컬럼명과 매핑
     private String fileSavedName;
 
+    @Column(name = "file_origin_name")
+    private String fileOriginName;
+
 
     @Column(name = "max_capacity")
     private Integer maxCapacity;
@@ -52,7 +55,7 @@ public class InsLecture {
     private Long instructorId = 2L; // "// TODO: 로그인 연동 후 세션 기반으로 변경 예정"
 
     @Builder
-    private InsLecture(String title, String description, String videoUrl, String fileSavedName,
+    private InsLecture(String title, String description, String videoUrl, String fileSavedName, String fileOriginName,
                        Integer maxCapacity, String lectureDay, LocalTime startTime, LocalTime endTime,Long instructorId) {
         this.title = title;
         this.description = description;
@@ -68,5 +71,22 @@ public class InsLecture {
         this.instructorId = instructorId;
         this.status = "OPEN";
 
+    }
+    public void updateInfo(String title, String description, String videoUrl,
+                           Integer maxCapacity, String lectureDay,
+                           java.time.LocalTime startTime, java.time.LocalTime endTime) {
+        this.title = title;
+        this.description = description;
+        this.videoUrl = videoUrl;
+        this.maxCapacity = maxCapacity;
+        this.lectureDay = lectureDay;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    // 파일 정보 수정 메서드
+    public void updateFileName(String fileOriginName, String fileSavedName) {
+        this.fileOriginName = fileOriginName;
+        this.fileSavedName = fileSavedName;
     }
 }

--- a/src/main/java/com/wanted/cookielms/domain/lecture/service/InstructorService.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/service/InstructorService.java
@@ -33,9 +33,7 @@ public class InstructorService {
     @Transactional
     public void registLecture(LectureInsDTO dto, Long instructorId) throws IOException {
 
-        // 1. 파일 저장 (PDF 검증 포함)
         String fileSavedName = saveFile(dto.getLectureFile());
-
 
         InsLecture lecture = InsLecture.builder()
                 .title(dto.getTitle())
@@ -45,8 +43,8 @@ public class InstructorService {
 
                 .maxCapacity(dto.getMaxCapacity())
                 .lectureDay(dto.getLectureDay())
-                .startTime(LocalTime.parse(dto.getStartTime())) // "09:00" 문자열 -> LocalTime 변환
-                .endTime(LocalTime.parse(dto.getEndTime()))     // "10:00" 문자열 -> LocalTime 변환
+                .startTime(LocalTime.parse(dto.getStartTime()))
+                .endTime(LocalTime.parse(dto.getEndTime()))
 
                 .instructorId(instructorId)
                 .build();
@@ -64,18 +62,18 @@ public class InstructorService {
 
         String originalName = file.getOriginalFilename();
 
-        // 1. 확장자 체크
+
         if (originalName == null || !originalName.toLowerCase().endsWith(".pdf")) {
             throw new IllegalArgumentException("맞지 않는 형식의 파일입니다. PDF만 업로드 해주세요.");
         }
 
-        // 2. 용량 체크 (5MB)
+
         long maxSize = 5 * 1024 * 1024;
         if (file.getSize() > maxSize) {
             throw new IllegalArgumentException("5MB를 초과합니다. 5MB 이하의 PDF를 업로드 해주세요.");
         }
 
-        // 3. 실제 폴더에 저장
+
         String ext = originalName.substring(originalName.lastIndexOf("."));
         String savedName = UUID.randomUUID().toString() + ext;
         File target = new File(uploadPath, savedName);
@@ -98,7 +96,7 @@ public class InstructorService {
     }
     @Transactional //
     public void updateLecture(Long id, LectureInsDTO dto) throws IOException {
-        // 1. 기존 강의 엔티티 조회 (DB에서 가져오기)
+
         InsLecture lecture = lectureInsRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강의입니다. ID: " + id));
 
@@ -108,8 +106,6 @@ public class InstructorService {
             lecture.updateFileName(dto.getLectureFile().getOriginalFilename(), savedName);
         }
 
-        // 3. 정보 업데이트 (JPA 변경 감지 활용)
-        // LocalTime.parse를 사용해 DTO의 String을 시간 객체로 변환합니다.
         lecture.updateInfo(
                 dto.getTitle(),
                 dto.getDescription(),
@@ -126,10 +122,9 @@ public class InstructorService {
             InsLecture lecture = lectureInsRepository.findById(id)
                     .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강의입니다. ID: " + id));
 
-            // ModelMapper를 사용하여 DTO로 변환하거나 직접 빌더를 사용합니다.
+
             LectureInsDTO dto = modelMapper.map(lecture, LectureInsDTO.class);
 
-            // LocalTime을 String으로 변환해서 넣어줍니다. (HTML input type="time" 바인딩용)
             dto.setStartTime(lecture.getStartTime().toString());
             dto.setEndTime(lecture.getEndTime().toString());
 

--- a/src/main/java/com/wanted/cookielms/domain/lecture/service/InstructorService.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/service/InstructorService.java
@@ -6,6 +6,7 @@ import com.wanted.cookielms.domain.lecture.entity.InsLecture;
 import com.wanted.cookielms.domain.lecture.repository.LectureInsRepository;
 import com.wanted.cookielms.domain.lecture.repository.LectureStuRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,6 +21,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Setter
 @Transactional(readOnly = true)
 public class InstructorService {
 
@@ -94,4 +96,43 @@ public class InstructorService {
 
         return myLectures.map(entity -> modelMapper.map(entity, LectureStuDTO.class));
     }
- }
+    @Transactional //
+    public void updateLecture(Long id, LectureInsDTO dto) throws IOException {
+        // 1. 기존 강의 엔티티 조회 (DB에서 가져오기)
+        InsLecture lecture = lectureInsRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강의입니다. ID: " + id));
+
+        // 2. 파일 수정 처리 (새 파일이 업로드된 경우에만 교체)
+        if (dto.getLectureFile() != null && !dto.getLectureFile().isEmpty()) {
+            String savedName = saveFile(dto.getLectureFile());
+            lecture.updateFileName(dto.getLectureFile().getOriginalFilename(), savedName);
+        }
+
+        // 3. 정보 업데이트 (JPA 변경 감지 활용)
+        // LocalTime.parse를 사용해 DTO의 String을 시간 객체로 변환합니다.
+        lecture.updateInfo(
+                dto.getTitle(),
+                dto.getDescription(),
+                dto.getVideoUrl(),
+                dto.getMaxCapacity(),
+                dto.getLectureDay(),
+                LocalTime.parse(dto.getStartTime()),
+                LocalTime.parse(dto.getEndTime())
+        );
+
+    }
+
+        public LectureInsDTO getLectureForEdit(Long id) {
+            InsLecture lecture = lectureInsRepository.findById(id)
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강의입니다. ID: " + id));
+
+            // ModelMapper를 사용하여 DTO로 변환하거나 직접 빌더를 사용합니다.
+            LectureInsDTO dto = modelMapper.map(lecture, LectureInsDTO.class);
+
+            // LocalTime을 String으로 변환해서 넣어줍니다. (HTML input type="time" 바인딩용)
+            dto.setStartTime(lecture.getStartTime().toString());
+            dto.setEndTime(lecture.getEndTime().toString());
+
+            return dto;
+        }
+    }

--- a/src/main/resources/templates/role/instructor/lecture_list.html
+++ b/src/main/resources/templates/role/instructor/lecture_list.html
@@ -8,10 +8,13 @@
 <h2>강사 나의 강의 목록 페이지</h2>
 <p>현재 로그인한 강사님이 등록한 강의 목록입니다.</p>
 
-<div th:each="lecture : ${lectures.content}">
-    <p th:text="${lecture.title}">강의 제목</p>
+<div th:each="lecture : ${lectures.content}" style="margin-bottom: 15px;">
+    <p>
+        <span th:text="${lecture.lectureId}">강의번호</span>
+        <span th:text="${lecture.title}" style="font-weight: bold;">강의 제목</span>
+        <button th:onclick="|location.href='@{/instructor/lecture/edit/{id}(id=${lecture.lectureId})}'|">수정하기</button>
+    </p>
 </div>
-
 <button th:onclick="|location.href='@{/instructor/lecture/regist}'|">새 강의 등록하기</button>
 </body>
 </html>

--- a/src/main/resources/templates/role/instructor/lecture_regist.html
+++ b/src/main/resources/templates/role/instructor/lecture_regist.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
   <meta charset="UTF-8">
-  <title>강의 등록</title>
+  <title>강의 등록/수정</title>
   <style>
     body { font-family: 'Malgun Gothic', sans-serif; padding: 20px; background-color: #f4f7f6; color: #333; }
     .container { max-width: 600px; margin: auto; background: white; padding: 30px; border-radius: 12px; box-shadow: 0 4px 15px rgba(0,0,0,0.1); }
@@ -17,23 +17,30 @@
 </head>
 <body>
 <div class="container">
-  <h2>강의 등록 (강사용)</h2>
 
-  <form th:action="@{/instructor/lecture/regist}" method="post" enctype="multipart/form-data">
+  <!-- 1. 제목 분기 -->
+  <h2 th:text="${isEdit} ? '강의 수정 (강사용)' : '강의 등록 (강사용)'">강의 등록 (강사용)</h2>
 
+
+  <form th:action="${isEdit} ? @{/instructor/lecture/edit/{id}(id=${lecture.lectureId})} : @{/instructor/lecture/regist}"
+        method="post" enctype="multipart/form-data">
+
+    <!-- 3. 기존 값 채우기 -->
     <div>
       <label>강의 제목:</label>
-      <input type="text" name="title" required placeholder="강의 제목을 입력하세요">
+      <input type="text" name="title" th:value="${lecture?.title}" required placeholder="강의 제목을 입력하세요">
     </div>
 
     <div>
       <label>강의 설명:</label>
-      <textarea name="description" required placeholder="강의 상세 설명"></textarea>
+      <textarea name="description" required placeholder="강의 상세 설명"
+                th:text="${lecture?.description}"></textarea>
     </div>
 
     <div>
       <label>유튜브 영상 주소:</label>
-      <input type="text" name="videoUrl" placeholder="https://..." required autocomplete="off">
+      <input type="text" name="videoUrl" th:value="${lecture?.videoUrl}"
+             placeholder="https://..." required autocomplete="off">
     </div>
 
     <div style="padding: 20px; background: #FFEB3B; border: 3px dashed #F44336; border-radius: 12px; margin: 20px 0;">
@@ -42,33 +49,50 @@
       <div style="display: flex; gap: 15px; margin-bottom: 15px;">
         <div style="flex: 1;">
           <label style="color: #333;">👥 최대 인원</label>
-          <input type="number" name="maxCapacity" value="30" required style="width: 100%; height: 40px; font-size: 16px;">
+          <input type="number" name="maxCapacity"
+                 th:value="${lecture?.maxCapacity} ?: 30"
+                 required style="width: 100%; height: 40px; font-size: 16px;">
         </div>
         <div style="flex: 1;">
           <label style="color: #333;">📅 강의 요일</label>
-          <input type="text" name="lectureDay" placeholder="예: 월요일" required style="width: 100%; height: 40px; font-size: 16px;">
+          <input type="text" name="lectureDay"
+                 th:value="${lecture?.lectureDay}"
+                 placeholder="예: 월요일" required style="width: 100%; height: 40px; font-size: 16px;">
         </div>
       </div>
 
       <div style="display: flex; gap: 15px;">
         <div style="flex: 1;">
           <label style="color: #333;">⏰ 시작 시간</label>
-          <input type="time" name="startTime" required style="width: 100%; height: 40px; font-size: 16px;">
+          <input type="time" name="startTime"
+                 th:value="${lecture?.startTime}"
+                 required style="width: 100%; height: 40px; font-size: 16px;">
         </div>
         <div style="flex: 1;">
           <label style="color: #333;">⌛ 종료 시간</label>
-          <input type="time" name="endTime" required style="width: 100%; height: 40px; font-size: 16px;">
+          <input type="time" name="endTime"
+                 th:value="${lecture?.endTime}"
+                 required style="width: 100%; height: 40px; font-size: 16px;">
         </div>
       </div>
     </div>
 
+    <!-- 4. 파일 업로드 (수정 시 required 해제) -->
     <div>
       <label>수업 자료 (PDF만 가능, 최대 5MB):</label>
-      <input type="file" name="lectureFile" id="lectureFile" accept=".pdf" required onchange="validateFile(this)">
+      <input type="file" name="lectureFile" id="lectureFile"
+             accept=".pdf"
+             th:required="${!isEdit}"
+             onchange="validateFile(this)">
+      <p th:if="${isEdit}" style="font-size: 12px; color: #666;">
+        * 파일을 선택하지 않으면 기존 파일이 유지됩니다.
+      </p>
     </div>
 
+    <!-- 5. 버튼 텍스트 분기 -->
     <div style="display: flex; gap: 10px; margin-top: 30px;">
-      <button type="submit" style="flex: 2;">등록하기</button>
+      <button type="submit" style="flex: 2;"
+              th:text="${isEdit} ? '수정 완료' : '등록하기'">등록하기</button>
       <button type="button"
               th:onclick="|location.href='@{/instructor/lectures}'|"
               style="flex: 1; background-color: #6c757d;">
@@ -81,12 +105,10 @@
 
 <script th:inline="javascript">
   function validateFile(input) {
-    const file = input.files[0];  // ← 버그 수정: files[0]으로 변경
+    const file = input.files[0];
     if (!file) return;
 
-    const fileName = file.name;
-    const fileExtension = fileName.split('.').pop().toLowerCase();
-
+    const fileExtension = file.name.split('.').pop().toLowerCase();
     if (fileExtension !== 'pdf') {
       alert("❌ 맞지 않는 형식의 파일입니다. PDF만 업로드 해주세요.");
       resetFile(input);
@@ -94,7 +116,7 @@
     }
 
     const maxSize = 5 * 1024 * 1024;
-    if (file.size > maxSize) {  // ← 버그 수정: file.size 사용
+    if (file.size > maxSize) {
       alert("❌ 5MB를 초과합니다. 5MB 이하의 PDF를 업로드 해주세요.");
       resetFile(input);
       return;
@@ -109,17 +131,13 @@
     }
   }
 
+  /*<![CDATA[*/
+  const errorMsg = /*[[${errorMessage}]]*/ null;
+  if (errorMsg) alert("❌ " + errorMsg);
 
-  const errorMsg =  null;
-  if (errorMsg) {
-    alert("❌ " + errorMsg);
-  }
-
-  const successMsg =  null;
-  if (successMsg) {
-    alert(successMsg);
-  }
-
+  const successMsg = /*[[${message}]]*/ null;
+  if (successMsg) alert(successMsg);
+  /*]]>*/
 </script>
 </body>
 </html>


### PR DESCRIPTION
## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #34

---

## 📝 작업한 내용
<!-- 이번 PR에서 변경한 내용을 간략하게 설명해주세요 -->
강사용 강의 등록 및 기존 강의 수정 기능 구현

---

## 🖥️ 구현한 내용 시연 방법
<!-- 리뷰어가 직접 확인할 수 있도록 실행 방법 또는 테스트 절차를 작성해주세요 -->

1. localhost:8080/instructor/lectures 접속 (강사 전용 페이지)
2. 강의 등록] 버튼을 눌러 /instructor/lecture/regist 진입
3. 제목, 설명, 유튜브 URL, 요일, 시작/종료 시간 입력 및 PDF 수업 자료(5MB 이하) 첨부 후 등록
4. 목록에서 등록된 강의의 [수정] 버튼 클릭 (/instructor/lecture/edit/{id})
5. 기존에 입력한 데이터가 정상적으로 화면에 채워지는지 확인
6. 내용을 변경하거나 새로운 PDF 파일을 첨부한 뒤 수정 완료 클릭
---

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했습니다
- [x] 불필요한 주석 및 콘솔 로그를 제거했습니다
- [x] 관련 이슈와 연결했습니다
