### PR TITLE
faet/bug Fix. 상세사항 이슈 확인

### DIFF
--- a/src/main/java/com/wanted/cookielms/domain/auth/handler/AuthFailureHandler.java
+++ b/src/main/java/com/wanted/cookielms/domain/auth/handler/AuthFailureHandler.java
@@ -71,11 +71,14 @@ public class AuthFailureHandler extends SimpleUrlAuthenticationFailureHandler {
         }
 
         if (exception instanceof BadCredentialsException) {
-            return "아이디 또는 비밀번호가 일치하지 않습니다.";
-        } else if (exception instanceof InternalAuthenticationServiceException) {
-            return "내부 시스템 문제로 인해 요청을 처리할 수 없습니다.";
+            return "비밀번호가 맞지 않습니다.";
         } else if (exception instanceof UsernameNotFoundException) {
-            return "존재하지 않는 계정입니다.";
+            return "등록된 회원 정보가 없습니다.";
+        } else if (exception instanceof InternalAuthenticationServiceException) {
+            if (exception.getCause() instanceof UsernameNotFoundException) {
+                return "등록된 회원 정보가 없습니다.";
+            }
+            return "내부 시스템 문제로 인해 요청을 처리할 수 없습니다.";
         }
         return "알 수 없는 이유로 로그인에 실패하였습니다. (에러타입: " + exception.getClass().getSimpleName() + ")";
     }

--- a/src/main/java/com/wanted/cookielms/domain/user/controller/UserController.java
+++ b/src/main/java/com/wanted/cookielms/domain/user/controller/UserController.java
@@ -188,7 +188,13 @@ public class UserController {
         String loginId = (String) session.getAttribute("verifiedLoginId");
         LoginUserDTO userInfo = userService.findByUsername(loginId);
         model.addAttribute("userInfo", userInfo);
-        model.addAttribute("modifyUserInfo", new ModifyUserInfo());
+
+        ModifyUserInfo modifyUserInfo = new ModifyUserInfo();
+        modifyUserInfo.setName(userInfo.getName());
+        modifyUserInfo.setNickname(userInfo.getNickname());
+        modifyUserInfo.setEmail(userInfo.getEmail());
+        modifyUserInfo.setPhone(userInfo.getPhone());
+        model.addAttribute("modifyUserInfo", modifyUserInfo);
         return "user/mypage_edit";
     }
 

--- a/src/main/java/com/wanted/cookielms/domain/user/dto/ModifyUserInfo.java
+++ b/src/main/java/com/wanted/cookielms/domain/user/dto/ModifyUserInfo.java
@@ -1,6 +1,7 @@
 package com.wanted.cookielms.domain.user.dto;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
@@ -8,16 +9,24 @@ import lombok.Setter;
 @Getter
 @Setter
 public class ModifyUserInfo {
+
+    @NotBlank(message = "이름을 입력해주세요.")
     private String name;
+
+    @NotBlank(message = "닉네임을 입력해주세요.")
     private String nickname;
 
-    @Email
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
 
+    @NotBlank(message = "전화번호를 입력해주세요.")
     private String phone;
+
     private String currentPassword;
 
-    @Pattern(regexp = "^(?=.*[!@#$%^&*]).{8,}$", message = "비밀번호는 특수문자를 포함한 8자 이상이어야 합니다.")
+    // 빈 값이면 변경하지 않으므로 빈 문자열도 허용
+    @Pattern(regexp = "^$|^(?=.*[!@#$%^&*]).{8,}$", message = "비밀번호는 특수문자를 포함한 8자 이상이어야 합니다.")
     private String newPassword;
 
     private String newPasswordConfirm;

--- a/src/main/java/com/wanted/cookielms/domain/user/entity/User.java
+++ b/src/main/java/com/wanted/cookielms/domain/user/entity/User.java
@@ -62,6 +62,7 @@ public class User {
         this.updatedAt = updatedAt;
         this.role = role;
         this.status = status;
+        this.isDeleted = false;
     }
 
     public void updatePassword(String encodedPassword) {

--- a/src/main/java/com/wanted/cookielms/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/wanted/cookielms/domain/user/repository/UserRepository.java
@@ -2,20 +2,30 @@ package com.wanted.cookielms.domain.user.repository;
 
 import com.wanted.cookielms.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    // 활성 계정 조회 (isDeleted = false 또는 null)
+    @Query("SELECT u FROM User u WHERE u.loginId = :loginId AND (u.isDeleted IS NULL OR u.isDeleted = false)")
+    Optional<User> findByLoginIdAndIsDeletedFalse(@Param("loginId") String loginId);
+
     Optional<User> findByLoginId(String loginId);
 
+    @Query("SELECT COUNT(u) > 0 FROM User u WHERE u.loginId = :loginId AND (u.isDeleted IS NULL OR u.isDeleted = false)")
+    boolean existsByLoginIdAndIsDeletedFalse(@Param("loginId") String loginId);
 
-    boolean existsByLoginId(String userId);
+    @Query("SELECT COUNT(u) > 0 FROM User u WHERE u.email = :email AND (u.isDeleted IS NULL OR u.isDeleted = false)")
+    boolean existsByEmailAndIsDeletedFalse(@Param("email") String email);
 
-    boolean existsByEmail(String email);
+    @Query("SELECT u FROM User u WHERE u.name = :name AND u.phone = :phone AND (u.isDeleted IS NULL OR u.isDeleted = false)")
+    Optional<User> findByNameAndPhoneAndIsDeletedFalse(@Param("name") String name, @Param("phone") String phone);
 
-    Optional<User> findByNameAndPhone(String name, String phone);
-
-    Optional<User> findByLoginIdAndNameAndPhone(String loginId, String name, String phone);
+    @Query("SELECT u FROM User u WHERE u.loginId = :loginId AND u.name = :name AND u.phone = :phone AND (u.isDeleted IS NULL OR u.isDeleted = false)")
+    Optional<User> findByLoginIdAndNameAndPhoneAndIsDeletedFalse(@Param("loginId") String loginId, @Param("name") String name, @Param("phone") String phone);
 }

--- a/src/main/java/com/wanted/cookielms/domain/user/service/UserService.java
+++ b/src/main/java/com/wanted/cookielms/domain/user/service/UserService.java
@@ -28,11 +28,11 @@ public class UserService {
     @Transactional
     public String join(JoinUserDTO joinUserDTO){
 
-        if (userRepository.existsByLoginId(joinUserDTO.getLoginId())) {
+        if (userRepository.existsByLoginIdAndIsDeletedFalse(joinUserDTO.getLoginId())) {
             return null; // 중복된 아이디가 존재함을 null로 표시
         }
 
-        if (userRepository.existsByEmail(joinUserDTO.getEmail())) {
+        if (userRepository.existsByEmailAndIsDeletedFalse(joinUserDTO.getEmail())) {
             return null;
         }
 
@@ -56,23 +56,23 @@ public class UserService {
     }
 
     public LoginUserDTO findByUsername(String username) {
-        Optional<User> userOptional = userRepository.findByLoginId(username);
+        Optional<User> userOptional = userRepository.findByLoginIdAndIsDeletedFalse(username);
         return userOptional.map(user -> modelMapper.map(user, LoginUserDTO.class)).orElse(null);
     }
 
     public String findLoginIdByNameAndPhone(String name, String phone) {
-        Optional<User> lostIdUser = userRepository.findByNameAndPhone(name, phone);
+        Optional<User> lostIdUser = userRepository.findByNameAndPhoneAndIsDeletedFalse(name, phone);
         return lostIdUser.map(User -> User.getLoginId()).orElse(null);
     }
 
     public Boolean findByLoginIdAndNameAndPhone(String loginId, String name, String phone) {
-        Optional<User> lostpwdUser = userRepository.findByLoginIdAndNameAndPhone(loginId, name, phone);
+        Optional<User> lostpwdUser = userRepository.findByLoginIdAndNameAndPhoneAndIsDeletedFalse(loginId, name, phone);
         return lostpwdUser.isPresent();
     }
 
     @Transactional
     public void updatePassword(String loginId, String newPassword ) {
-        userRepository.findByLoginId(loginId)
+        userRepository.findByLoginIdAndIsDeletedFalse(loginId)
                 .ifPresent(user -> {user.updatePassword(passwordEncoder.encode(newPassword));
                 });
 
@@ -80,7 +80,7 @@ public class UserService {
 
     // 정보 조회 비번 확인용
     public boolean verifyPassword(String loginId, String password) {
-        return userRepository.findByLoginId(loginId)
+        return userRepository.findByLoginIdAndIsDeletedFalse(loginId)
                 .map(user -> passwordEncoder.matches(password, user.getPassword()))
                 .orElse(false);
     }
@@ -88,7 +88,7 @@ public class UserService {
 
     @Transactional
     public boolean updateUserInfo(String loginId, ModifyUserInfo dto) {
-        User user = userRepository.findByLoginId(loginId).orElse(null);
+        User user = userRepository.findByLoginIdAndIsDeletedFalse(loginId).orElse(null);
         if (user == null) return false;
 
         if (!passwordEncoder.matches(dto.getCurrentPassword(), user.getPassword())) {
@@ -109,7 +109,7 @@ public class UserService {
 
     @Transactional
     public boolean withdrawUser(String loginId, String password) {
-        User user = userRepository.findByLoginId(loginId).orElse(null);
+        User user = userRepository.findByLoginIdAndIsDeletedFalse(loginId).orElse(null);
         if (user == null) return false;
 
         if (!passwordEncoder.matches(password, user.getPassword())) {

--- a/src/main/java/com/wanted/cookielms/global/IndexController.java
+++ b/src/main/java/com/wanted/cookielms/global/IndexController.java
@@ -1,7 +1,9 @@
 package com.wanted.cookielms.global;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 public class IndexController {
@@ -27,6 +29,12 @@ public class IndexController {
     @GetMapping("/admin")
     public String adminMainPage(){
         return "admin/dashboard";
+    }
+
+    @ResponseBody
+    @GetMapping("/api/session/keep-alive")
+    public ResponseEntity<Void> keepAlive() {
+        return ResponseEntity.ok().build();
     }
 
     /*

--- a/src/main/java/com/wanted/cookielms/global/config/security/CustomUserDetailsService.java
+++ b/src/main/java/com/wanted/cookielms/global/config/security/CustomUserDetailsService.java
@@ -20,7 +20,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
-        User user = userRepository.findByLoginId(loginId)
+        User user = userRepository.findByLoginIdAndIsDeletedFalse(loginId)
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + loginId));
 
         LoginUserDTO loginUserDTO = modelMapper.map(user, LoginUserDTO.class);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -36,6 +36,9 @@ logging:
 
 # 서버 에러 처리 설정
 server:
+  servlet:
+    session:
+      timeout: 15m
   error:
     whitelabel:
       enabled: false  # Spring Boot 기본 에러 페이지 비활성화

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -175,5 +175,6 @@
         loadInstructorApplications(); loadRecentBans(); loadMetrics();
     });
 </script>
+<script src="/js/session-timer.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/instructor/lecture_list.html
+++ b/src/main/resources/templates/instructor/lecture_list.html
@@ -98,5 +98,6 @@
 </div>
 
 </div>
+<script src="/js/session-timer.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/instructor/lecture_regist.html
+++ b/src/main/resources/templates/instructor/lecture_regist.html
@@ -142,5 +142,6 @@
     if (successMsg) alert(successMsg);
     /*]]>*/
 </script>
+<script src="/js/session-timer.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/instructor/main.html
+++ b/src/main/resources/templates/instructor/main.html
@@ -76,5 +76,6 @@
         </a>
     </div>
 </div>
+<script src="/js/session-timer.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/student/lecture_detail.html
+++ b/src/main/resources/templates/student/lecture_detail.html
@@ -143,5 +143,6 @@
     function downloadMaterial(id) { window.location.href = `/lectures/${id}/material`; }
     function goToAssignment(id) { alert(id + "번 강의 과제 제출 페이지로 이동합니다."); }
 </script>
+<script src="/js/session-timer.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/user/assignment_submit.html
+++ b/src/main/resources/templates/user/assignment_submit.html
@@ -122,5 +122,6 @@
         }
     });
 </script>
+<script src="/js/session-timer.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/user/assignment_success.html
+++ b/src/main/resources/templates/user/assignment_success.html
@@ -41,5 +41,6 @@
     <p class="msg" th:text="${message}"></p>
     <a href="/student/lectures" class="btn">강의 목록으로 돌아가기</a>
 </div>
+<script src="/js/session-timer.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/user/enrollments.html
+++ b/src/main/resources/templates/user/enrollments.html
@@ -177,5 +177,6 @@
         }).catch(() => alert('서버 오류가 발생했습니다.'));
     }
 </script>
+<script src="/js/session-timer.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/user/lecture_detail.html
+++ b/src/main/resources/templates/user/lecture_detail.html
@@ -138,5 +138,6 @@
     function downloadMaterial(id) { if (!id) return; window.location.href = `/lectures/${id}/material`; }
     function goToAssignment(id) { if (!id) return; window.location.href = `/student/assignments/${id}`; }
 </script>
+<script src="/js/session-timer.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/user/lecture_stu_list.html
+++ b/src/main/resources/templates/user/lecture_stu_list.html
@@ -127,5 +127,6 @@
         }
     }
 </script>
+<script src="/js/session-timer.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/user/login.html
+++ b/src/main/resources/templates/user/login.html
@@ -41,7 +41,10 @@
             border: none; border-radius: 8px; font-size: 15px; font-weight: 600;
             cursor: pointer; margin-top: 8px; transition: background 0.2s;
         }
-        .btn-submit:hover { background: var(--btn-dark-hover); }
+        .btn-submit:hover:not(:disabled) { background: var(--btn-dark-hover); }
+        .btn-submit:disabled { background: var(--almond-silk); cursor: not-allowed; }
+        .field-error { font-size: 12px; color: #7a3020; margin-top: 5px; display: none; }
+        input.input-error { border-color: #c8a090; }
         .links { display: flex; justify-content: center; gap: 16px; margin-top: 20px; }
         .links a { font-size: 13px; color: var(--text-muted); text-decoration: none; }
         .links a:hover { color: var(--text-secondary); text-decoration: underline; }
@@ -54,16 +57,18 @@
     <h1>로그인</h1>
     <p class="subtitle">Cookiego에 오신 것을 환영합니다</p>
 
-    <form th:action="@{/user/login}" method="post">
+    <form th:action="@{/user/login}" method="post" id="loginForm">
         <div class="form-group">
             <label for="loginId">아이디</label>
             <input type="text" id="loginId" name="loginId" placeholder="아이디를 입력하세요">
+            <p class="field-error" id="loginId-error">아이디를 입력해주세요.</p>
         </div>
         <div class="form-group">
             <label for="password">비밀번호</label>
             <input type="password" id="password" name="password" placeholder="비밀번호를 입력하세요">
+            <p class="field-error" id="password-error">비밀번호를 입력해주세요.</p>
         </div>
-        <button type="submit" class="btn-submit">로그인</button>
+        <button type="submit" class="btn-submit" id="submitBtn" disabled>로그인</button>
     </form>
 
     <div class="links">
@@ -74,5 +79,56 @@
         <a th:href="@{/user/join}">회원가입</a>
     </div>
 </div>
+<script>
+    (function () {
+        // 서버 오류 alert
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('error') === 'true') {
+            const msg = params.get('message') || '로그인에 실패하였습니다.';
+            alert(msg);
+        }
+        if (params.get('expired') === 'true') {
+            alert('세션이 만료되었습니다. 다시 로그인해 주세요.');
+        }
+
+        const loginIdInput = document.getElementById('loginId');
+        const passwordInput = document.getElementById('password');
+        const submitBtn    = document.getElementById('submitBtn');
+        const loginIdError = document.getElementById('loginId-error');
+        const passwordError = document.getElementById('password-error');
+
+        function checkFields() {
+            const idFilled  = loginIdInput.value.trim() !== '';
+            const pwFilled  = passwordInput.value !== '';
+            submitBtn.disabled = !(idFilled && pwFilled);
+        }
+
+        function showError(input, errorEl) {
+            if (input.value.trim() === '') {
+                errorEl.style.display = 'block';
+                input.classList.add('input-error');
+            } else {
+                errorEl.style.display = 'none';
+                input.classList.remove('input-error');
+            }
+        }
+
+        loginIdInput.addEventListener('input', function () {
+            showError(loginIdInput, loginIdError);
+            checkFields();
+        });
+        loginIdInput.addEventListener('blur', function () {
+            showError(loginIdInput, loginIdError);
+        });
+
+        passwordInput.addEventListener('input', function () {
+            showError(passwordInput, passwordError);
+            checkFields();
+        });
+        passwordInput.addEventListener('blur', function () {
+            showError(passwordInput, passwordError);
+        });
+    })();
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/user/main.html
+++ b/src/main/resources/templates/user/main.html
@@ -77,5 +77,6 @@
         </a>
     </div>
 </div>
+<script src="/js/session-timer.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/user/mypage.html
+++ b/src/main/resources/templates/user/mypage.html
@@ -64,5 +64,6 @@
         </a>
     </div>
 </div>
+<script src="/js/session-timer.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/user/mypage_edit.html
+++ b/src/main/resources/templates/user/mypage_edit.html
@@ -64,18 +64,22 @@
         <div class="form-group">
             <label>이름</label>
             <input type="text" th:field="*{name}" placeholder="이름">
+            <p class="msg-error" th:if="${#fields.hasErrors('name')}" th:errors="*{name}"></p>
         </div>
         <div class="form-group">
             <label>닉네임</label>
             <input type="text" th:field="*{nickname}" placeholder="닉네임">
+            <p class="msg-error" th:if="${#fields.hasErrors('nickname')}" th:errors="*{nickname}"></p>
         </div>
         <div class="form-group">
             <label>이메일</label>
             <input type="email" th:field="*{email}" placeholder="이메일">
+            <p class="msg-error" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></p>
         </div>
         <div class="form-group">
             <label>전화번호</label>
             <input type="text" th:field="*{phone}" placeholder="전화번호">
+            <p class="msg-error" th:if="${#fields.hasErrors('phone')}" th:errors="*{phone}"></p>
         </div>
 
         <div class="section-label">비밀번호 변경</div>
@@ -100,5 +104,6 @@
         </div>
     </form>
 </div>
+<script src="/js/session-timer.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/user/mypage_info.html
+++ b/src/main/resources/templates/user/mypage_info.html
@@ -81,5 +81,6 @@
         <a th:href="@{/user/mypage}" class="btn btn-secondary">돌아가기</a>
     </div>
 </div>
+<script src="/js/session-timer.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/user/verify_password.html
+++ b/src/main/resources/templates/user/verify_password.html
@@ -62,5 +62,6 @@
         <button type="submit" class="btn-submit">확인</button>
     </form>
 </div>
+<script src="/js/session-timer.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/user/waitlist.html
+++ b/src/main/resources/templates/user/waitlist.html
@@ -68,5 +68,6 @@
             .catch(() => alert('서버 오류가 발생했습니다.'));
     }
 </script>
+<script src="/js/session-timer.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/user/withdraw.html
+++ b/src/main/resources/templates/user/withdraw.html
@@ -1,17 +1,81 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
-  <meta charset="UTF-8">
-  <title>회원 탈퇴</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>회원 탈퇴 - Cookiego</title>
+    <style>
+        :root {
+            --parchment: #edede9; --dust-grey: #d6ccc2; --linen: #f5ebe0;
+            --powder-petal: #e3d5ca; --almond-silk: #d5bdaf;
+            --text-primary: #2c2010; --text-secondary: #5c4a3a;
+            --text-muted: #8b7355; --text-on-dark: #f5ebe0;
+            --btn-dark: #4a3728; --btn-dark-hover: #2c2010;
+            --error: #7a3020; --shadow: rgba(44,32,16,0.10);
+        }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: 'Segoe UI', system-ui, sans-serif;
+            background: var(--parchment); color: var(--text-primary);
+            min-height: 100vh; display: flex; justify-content: center; align-items: center;
+        }
+        .card {
+            background: var(--linen); border: 1px solid var(--dust-grey);
+            border-radius: 16px; box-shadow: 0 4px 24px var(--shadow);
+            padding: 48px 40px; width: 100%; max-width: 400px;
+        }
+        .back-link {
+            display: inline-flex; align-items: center; gap: 4px;
+            font-size: 13px; color: var(--text-muted); margin-bottom: 28px; text-decoration: none;
+        }
+        .back-link:hover { color: var(--text-secondary); }
+        .danger-icon { font-size: 40px; margin-bottom: 16px; }
+        h1 { font-size: 22px; font-weight: 700; margin-bottom: 8px; color: var(--error); }
+        .warning-text {
+            font-size: 14px; color: var(--text-muted); margin-bottom: 28px;
+            padding: 12px 14px; background: #f9ede9;
+            border: 1px solid #e8c8c0; border-radius: 8px; line-height: 1.6;
+        }
+        .form-group { margin-bottom: 16px; }
+        label { display: block; font-size: 13px; font-weight: 600; color: var(--text-secondary); margin-bottom: 6px; }
+        input[type="password"] {
+            width: 100%; padding: 11px 14px; border: 1px solid var(--dust-grey);
+            border-radius: 8px; background: var(--parchment); color: var(--text-primary);
+            font-size: 15px; outline: none; transition: border-color 0.2s;
+        }
+        input[type="password"]:focus { border-color: var(--almond-silk); background: #fff; }
+        .msg-error { color: var(--error); font-size: 13px; margin-top: 6px; }
+        .btn-row { display: flex; gap: 10px; margin-top: 24px; }
+        .btn {
+            flex: 1; padding: 13px; border-radius: 8px; font-size: 15px;
+            font-weight: 600; cursor: pointer; border: none; text-align: center;
+            text-decoration: none; transition: all 0.2s;
+        }
+        .btn-danger { background: #a83020; color: #fff; }
+        .btn-danger:hover { background: #7a2016; }
+        .btn-secondary { background: var(--almond-silk); color: var(--text-primary); }
+        .btn-secondary:hover { background: var(--powder-petal); }
+    </style>
 </head>
 <body>
-<h1>회원 탈퇴</h1>
-<p>탈퇴 시 모든 정보는 삭제되며 복구가 불가능합니다.</p>
-<form th:action="@{/user/withdraw}" method="post">
-  <input type="password" name="password" placeholder="비밀번호 확인"><br>
-  <p th:if="${error}" th:text="${error}" style="color:red"></p>
-  <button type="submit">탈퇴하기</button>
-</form>
-<a th:href="@{/user/mypage}">마이페이지로 돌아가기</a>
+<div class="card">
+    <a th:href="@{/user/mypage}" class="back-link">← 마이페이지로</a>
+    <div class="danger-icon">⚠️</div>
+    <h1>회원 탈퇴</h1>
+    <p class="warning-text">탈퇴 시 모든 정보는 즉시 삭제되며 복구가 불가능합니다.<br>정말 탈퇴하시겠습니까?</p>
+
+    <form th:action="@{/user/withdraw}" method="post">
+        <div class="form-group">
+            <label for="password">비밀번호 확인</label>
+            <input type="password" id="password" name="password" placeholder="현재 비밀번호를 입력하세요">
+            <p class="msg-error" th:if="${error}" th:text="${error}"></p>
+        </div>
+        <div class="btn-row">
+            <button type="submit" class="btn btn-danger">탈퇴하기</button>
+            <a th:href="@{/user/mypage}" class="btn btn-secondary">취소</a>
+        </div>
+    </form>
+</div>
+<script src="/js/session-timer.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #108
- Closes #109
- Closes #110 
- Closes #111 

---

## 📝 작업한 내용
<!-- 이번 PR에서 변경한 내용을 간략하게 설명해주세요 -->
**[feat] 세션 타이머**
- 서버 세션 타임아웃 15분 설정
- 모든 인증 페이지 우측 상단에 잔여 세션 시간 실시간 표시
- 2분 이하 주황, 30초 이하 빨강 경고, 만료 시 로그인 페이지 이동
- 연장 버튼 클릭 시 `/api/session/keep-alive` 호출로 15분 리셋

**[feat] 로그인 페이지 UX 개선**
- 아이디·비밀번호 미입력 시 로그인 버튼 비활성화
- 빈 칸 감지 시 필드 아래  오류 메시지 표시

**[feat] 정보 수정 폼 개선**
- GET 진입 시 기존 사용자 정보 폼에 pre-fill
- 이름·닉네임·이메일·전화번호 `@NotBlank` 서버 검증 추가
- 새 비밀번호는 빈값 허용 (변경 시에만 패턴 검증)

**[fix] 로그인 실패 메시지 구분**
- 아이디 없음 / 비밀번호 틀림 메시지 각각 분리

**[fix] 소프트 삭제 계정 관련 버그 수정**
- `existsByLoginId` → 탈퇴 계정 제외 쿼리로 교체 (재가입 허용)
- 아이디 찾기·비밀번호 찾기 쿼리에 탈퇴 계정 필터 추가
- `User` 생성자에서 `isDeleted = false` 초기화
- Repository 쿼리 전체 `@Query`로 교체, `IS NULL OR = false` 조건으로 기존 데이터 호환 처리

---

## 🖥️ 구현한 내용 시연 방법
<!-- 리뷰어가 직접 확인할 수 있도록 실행 방법 또는 테스트 절차를 작성해주세요 -->

1. . 로그인 페이지에서 아이디·비밀번호 미입력 후 버튼 비활성화 확인
2. 로그인 실패 시 아이디 없음 / 비밀번호 틀림 각각 alert 메시지 확인
3. 로그인 후 우측 상단 세션 타이머 표시 및 연장 버튼 동작 확인
4. 마이페이지 → 정보 수정 진입 시 기존 정보 자동 입력 확인
5. 회원 탈퇴 후 동일 아이디로 재가입 가능 여부 확인
6. 탈퇴 계정으로 비밀번호 찾기 시도 → 실패 확인
---

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다
- [ ] 불필요한 주석 및 콘솔 로그를 제거했습니다
- [ ] 관련 이슈와 연결했습니다
