### PR TITLE
[Feat] 강의 전체목록 조회 -> 내 강의 조회로 변경 및 조회 시 강사ID 대신 이름 표시

### DIFF
--- a/src/main/java/com/wanted/cookielms/domain/lecture/controller/LectureStuController.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/controller/LectureStuController.java
@@ -2,6 +2,7 @@ package com.wanted.cookielms.domain.lecture.controller;
 
 import com.wanted.cookielms.domain.auth.dto.AuthDetails;
 import com.wanted.cookielms.domain.lecture.dto.LectureStuDTO;
+import com.wanted.cookielms.domain.lecture.dto.MyLectureListDTO;
 import com.wanted.cookielms.domain.lecture.service.LectureStuService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.ByteArrayResource;
@@ -10,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -33,12 +35,29 @@ public class LectureStuController {
         return authDetails.getLoginUserDTO().getUserId();
     }
 
+    // 🌟 전체 강의 조회 (수강신청 페이지용)
     @GetMapping
     @ResponseBody
     public ResponseEntity<Page<LectureStuDTO>> getLectures(
             @RequestParam(required = false) String keyword,
             @PageableDefault(size = 6) Pageable pageable) {
         return ResponseEntity.ok(lectureStuService.getAllLectures(keyword, pageable));
+    }
+
+    // 🌟 내 강의 조회 (내 강의 목록 페이지용)
+    @GetMapping("/my")
+    @ResponseBody
+    public ResponseEntity<Page<MyLectureListDTO>> getMyLectures(
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 6) Pageable pageable,
+            Authentication authentication) {
+
+        Long userId = getLoginUserId(authentication);
+        if (userId == -1L) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        return ResponseEntity.ok(lectureStuService.getMyLectures(userId, keyword, pageable));
     }
 
     @GetMapping("/{lectureId}")
@@ -52,18 +71,26 @@ public class LectureStuController {
     @ResponseBody
     public ResponseEntity<String> getLectureVideoUrl(@PathVariable Long lectureId, Authentication authentication) {
         Long userId = getLoginUserId(authentication);
-        return ResponseEntity.ok(lectureStuService.getVideoUrl(lectureId, userId));
+        try {
+            return ResponseEntity.ok(lectureStuService.getVideoUrl(lectureId, userId));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+        }
     }
 
     @GetMapping("/{lectureId}/material")
     @ResponseBody
     public ResponseEntity<Resource> downloadLectureMaterial(@PathVariable Long lectureId, Authentication authentication) {
         Long userId = getLoginUserId(authentication);
-        String materialId = lectureStuService.getMaterialId(lectureId, userId);
-        byte[] fileData = "파일 내용 예시".getBytes(StandardCharsets.UTF_8);
-        return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + materialId + "\"")
-                .contentType(MediaType.APPLICATION_OCTET_STREAM)
-                .body(new ByteArrayResource(fileData));
+        try {
+            String materialId = lectureStuService.getMaterialId(lectureId, userId);
+            byte[] fileData = "파일 내용 예시".getBytes(StandardCharsets.UTF_8);
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + materialId + "\"")
+                    .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                    .body(new ByteArrayResource(fileData));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
     }
 }

--- a/src/main/java/com/wanted/cookielms/domain/lecture/dto/LectureStuDTO.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/dto/LectureStuDTO.java
@@ -18,9 +18,14 @@ public class LectureStuDTO {
     private String thumbnail;
     private String materialId;
 
-    // 🌟 ModelMapper가 헷갈리지 않게 전혀 다른 이름으로 변경!
     private boolean userEnrolled;
     private boolean userInstructor;
+
+    private String instructorName; // 강사 이름 추가
+
+    public void setInstructorName(String instructorName) {
+        this.instructorName = instructorName;
+    }
 
     public void setUserEnrolled(boolean userEnrolled) {
         this.userEnrolled = userEnrolled;

--- a/src/main/java/com/wanted/cookielms/domain/lecture/dto/MyLectureListDTO.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/dto/MyLectureListDTO.java
@@ -1,0 +1,15 @@
+package com.wanted.cookielms.domain.lecture.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MyLectureListDTO {
+    private Long lectureId;
+    private String title;
+    private String instructorName;
+    private int currentEnrollment;
+    private int maxCapacity;
+    private String thumbnail;
+}

--- a/src/main/java/com/wanted/cookielms/domain/lecture/entity/LectureStuEntity.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/entity/LectureStuEntity.java
@@ -49,6 +49,9 @@ public class LectureStuEntity {
     @Column(name = "material_id", length = 500)
     private String materialId; // 화면에서 썸네일 경로로 쓸 컬럼
 
+    @Column(name = "thumbnail", length = 500)
+    private String thumbnail;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/wanted/cookielms/domain/lecture/repository/LectureStuRepository.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/repository/LectureStuRepository.java
@@ -1,14 +1,35 @@
 package com.wanted.cookielms.domain.lecture.repository;
 
+import com.wanted.cookielms.domain.lecture.dto.MyLectureListDTO;
 import com.wanted.cookielms.domain.lecture.entity.LectureStuEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LectureStuRepository extends JpaRepository<LectureStuEntity, Long> {
 
-    // 강의 제목에 'keyword'가 포함된 것만 찾아오는 메서드
+    // 🌟 수강신청 페이지용 전체 강의 검색 메서드 복구!
     Page<LectureStuEntity> findByTitleContaining(String keyword, Pageable pageable);
+
+    // 🌟 내 강의 전용 성능 최적화(DTO Projection)
+    @Query("SELECT new com.wanted.cookielms.domain.lecture.dto.MyLectureListDTO(" +
+            "l.lectureId, l.title, u.name, l.currentEnrollment, l.maxCapacity, l.thumbnail) " +
+            "FROM LectureStuEntity l " +
+            "JOIN Enrollment e ON l.lectureId = e.lectureId " +
+            "JOIN User u ON l.instructorId = u.userId " +
+            "WHERE e.userId = :userId AND e.status = 'ENROLLED' " +
+            "AND (:keyword IS NULL OR l.title LIKE CONCAT('%', :keyword, '%'))")
+    Page<MyLectureListDTO> findMyLecturesWithProjection(
+            @Param("userId") Long userId,
+            @Param("keyword") String keyword,
+            Pageable pageable);
+
+    // 🌟 강사 ID로 강사 이름(name)만 쏙 빼오는 쿼리 (여기에 추가!)
+    @Query("SELECT u.name FROM User u WHERE u.userId = :instructorId")
+    String findInstructorNameById(@Param("instructorId") Long instructorId);
+
 }

--- a/src/main/java/com/wanted/cookielms/domain/lecture/service/LectureStuService.java
+++ b/src/main/java/com/wanted/cookielms/domain/lecture/service/LectureStuService.java
@@ -2,6 +2,7 @@ package com.wanted.cookielms.domain.lecture.service;
 
 import com.wanted.cookielms.domain.enrollment.repository.EnrollmentRepository;
 import com.wanted.cookielms.domain.lecture.dto.LectureStuDTO;
+import com.wanted.cookielms.domain.lecture.dto.MyLectureListDTO;
 import com.wanted.cookielms.domain.lecture.entity.LectureStuEntity;
 import com.wanted.cookielms.domain.lecture.exception.LectureErrorCode;
 import com.wanted.cookielms.domain.lecture.exception.LectureException;
@@ -22,6 +23,7 @@ public class LectureStuService {
     private final EnrollmentRepository enrollmentRepository;
     private final ModelMapper modelMapper;
 
+    // 🌟 전체 강의 목록 조회 (수강신청 페이지용 복구)
     public Page<LectureStuDTO> getAllLectures(String keyword, Pageable pageable) {
         Page<LectureStuEntity> lectures;
         if (keyword == null || keyword.trim().isEmpty()) {
@@ -32,7 +34,13 @@ public class LectureStuService {
         return lectures.map(entity -> modelMapper.map(entity, LectureStuDTO.class));
     }
 
-    // 학생용 상세 조회 (수강생/강사 여부 체크 포함)
+    // 🌟 내 강의만 가져오는 최적화된 로직
+    public Page<MyLectureListDTO> getMyLectures(Long userId, String keyword, Pageable pageable) {
+        String safeKeyword = (keyword == null || keyword.trim().isEmpty()) ? null : keyword;
+        return lectureStuRepository.findMyLecturesWithProjection(userId, safeKeyword, pageable);
+    }
+
+    // 🌟 강의 상세 조회 (여기에 강사 이름 가져오기가 쏙 들어갔어요!)
     public LectureStuDTO getLectureDetail(Long lectureId, Long userId) {
         LectureStuEntity entity = lectureStuRepository.findById(lectureId)
                 .orElseThrow(() -> new LectureException(LectureErrorCode.LECTURE_NOT_FOUND));
@@ -41,6 +49,10 @@ public class LectureStuService {
 
         boolean isEnrolled = enrollmentRepository.existsByUserIdAndLectureIdAndStatus(userId, lectureId, "ENROLLED");
         boolean isInstructor = entity.getInstructorId().equals(userId);
+
+        // 🌟 강사 이름 가져와서 DTO에 꽂아주기! (하연님이 물어보신 부분!)
+        String instructorName = lectureStuRepository.findInstructorNameById(entity.getInstructorId());
+        dto.setInstructorName(instructorName);
 
         dto.setUserEnrolled(isEnrolled);
         dto.setUserInstructor(isInstructor);

--- a/src/main/resources/templates/user/lecture_detail.html
+++ b/src/main/resources/templates/user/lecture_detail.html
@@ -105,7 +105,7 @@
                 document.getElementById('lectureTitle').innerText = d.title;
                 document.getElementById('modalTitle').innerText = d.title;
                 document.getElementById('lectureDesc').innerText = d.description;
-                document.getElementById('instructorInfo').innerText = `강사 ID: ${d.instructorId}`;
+                document.getElementById('instructorInfo').innerText = `👨‍🏫 강사명: ${d.instructorName}`;
                 document.getElementById('capacityInfo').innerText = `인원: ${d.currentEnrollment} / ${d.maxCapacity} 명`;
                 if (d.thumbnail) {
                     document.getElementById('thumbnailArea').innerHTML = `<img src="/images/${d.thumbnail}" alt="${d.title}" onerror="this.style.display='none';this.parentNode.innerText='이미지 없음';">`;
@@ -118,7 +118,7 @@
                     area.innerHTML = `
                         <button class="action-btn" onclick="playVideo(${lectureId})">▶ 강의 영상 재생</button>
                         <button class="action-btn" onclick="downloadMaterial(${lectureId})">↓ 학습 자료 다운로드</button>
-                        <button class="action-btn" onclick="goToAssignment(${lectureId})">✎ 과제 제출/확인하기</button>`;
+                        <button class="action-btn" onclick="goToAssignment(${lectureId})">✎ 과제 제출하기</button>`;
                 } else {
                     area.innerHTML = `<div class="locked-box">🔒 강의를 시청하시려면 먼저 수강신청을 완료해주세요.<small>수강신청은 '강의 등록' 페이지에서 진행하실 수 있습니다.</small></div>`;
                 }

--- a/src/main/resources/templates/user/lecture_stu_list.html
+++ b/src/main/resources/templates/user/lecture_stu_list.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>전체 강의 목록 - Cookiego</title>
+    <title> 강의 목록 - Cookiego</title>
     <style>
         :root {
             --parchment: #edede9; --dust-grey: #d6ccc2; --linen: #f5ebe0;
@@ -73,7 +73,7 @@
 </header>
 
 <div class="main">
-    <div class="page-title">전체 강의 목록</div>
+    <div class="page-title">강의 목록</div>
     <div class="search-bar">
         <input type="text" id="searchInput" class="search-input" placeholder="강의 제목을 검색해보세요" onkeyup="if(event.keyCode===13) searchLectures()">
         <button class="search-btn" onclick="searchLectures()">검색</button>
@@ -88,12 +88,20 @@
     function searchLectures() { loadLectures(document.getElementById('searchInput').value, 0); }
 
     function loadLectures(keyword, page) {
-        let url = `/lectures?page=${page}&size=6`;
+        // '내 강의' API를 호출
+        let url = `/lectures/my?page=${page}&size=6`;
         if (keyword) url += `&keyword=${encodeURIComponent(keyword)}`;
+
         fetch(url).then(r => r.json()).then(data => {
             const grid = document.getElementById('lectureList');
             grid.innerHTML = '';
-            if (!data.content.length) { grid.innerHTML = '<div class="empty">강의가 없습니다.</div>'; document.getElementById('pagination').innerHTML = ''; return; }
+
+            if (!data.content.length) {
+                grid.innerHTML = '<div class="empty">등록된 수강 강의가 없습니다. 검색을 통해 새로운 강의를 찾아보세요!</div>';
+                document.getElementById('pagination').innerHTML = '';
+                return;
+            }
+
             data.content.forEach(l => {
                 const thumb = l.thumbnail
                     ? `<img src="/images/${l.thumbnail}" alt="썸네일">`
@@ -104,14 +112,14 @@
                         <div class="card-body">
                             <div class="card-title">${l.title}</div>
                             <div class="card-info">
-                                강사 ID: ${l.instructorId}<br>
-                                수강 인원: ${l.currentEnrollment} / ${l.maxCapacity} 명
+                                👨‍🏫 강사명: ${l.instructorName}<br>
+                                👥 수강 인원: ${l.currentEnrollment} / ${l.maxCapacity} 명
                             </div>
                         </div>
                     </div>`;
             });
             renderPagination(data.totalPages, data.number, keyword);
-        }).catch(e => console.error(e));
+        }).catch(e => console.error("내 강의 목록 로딩 실패:", e));
     }
 
     function renderPagination(total, cur, keyword) {


### PR DESCRIPTION
## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #105
- Closes #106 

---

## 📝 작업한 내용
<!-- 이번 PR에서 변경한 내용을 간략하게 설명해주세요 -->
강의 전체목록 조회 -> 내 강의 조회로 변경
조회 시 강사ID 대신 이름 표시

---

## 🖥️ 구현한 내용 시연 방법
<!-- 리뷰어가 직접 확인할 수 있도록 실행 방법 또는 테스트 절차를 작성해주세요 -->

1. 학생으로 로그인 후 내 강의 목록 버튼 클릭하면 전체 강의 목록 대신 해당 학생이 수강 신청한 강의만 조회됨
2. 강의 썸네일 클릭하면 강사ID 대신 강사 이름이 표시됨
3. 

---

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다
- [ ] 관련 이슈와 연결했습니다
