### PR TITLE
[FIX] error log

### DIFF
--- a/src/main/java/com/wanted/cookielms/domain/admin/service/ErrorLogQueryService.java
+++ b/src/main/java/com/wanted/cookielms/domain/admin/service/ErrorLogQueryService.java
@@ -2,7 +2,6 @@ package com.wanted.cookielms.domain.admin.service;
 
 import com.wanted.cookielms.domain.admin.dto.CriticalErrorDetailDto;
 import com.wanted.cookielms.domain.admin.dto.CriticalErrorListItemDto;
-import com.wanted.cookielms.global.logging.api.repository.ApiPerformanceLogRepository;
 import com.wanted.cookielms.global.logging.error.entity.enums.ErrorSeverity;
 import com.wanted.cookielms.global.logging.error.dto.ErrorLogResponseDTO;
 import com.wanted.cookielms.global.logging.error.entity.ErrorLogEntity;
@@ -24,7 +23,6 @@ import java.util.stream.Collectors;
 public class ErrorLogQueryService {
 
     private final ErrorLogRepository errorLogRepository;
-    private final ApiPerformanceLogRepository apiPerformanceLogRepository;
 
     /**
      * [조회 1] 모든 에러 로그 (페이징)
@@ -86,17 +84,11 @@ public class ErrorLogQueryService {
     }
 
     /**
-     * [조회 8] 특정 사용자의 에러 로그 (API 로그를 통한 join)
+     * [조회 8] 특정 사용자의 에러 로그 (error_logs.user_id 직접 조회)
+     * Security 필터 차단(403) 케이스도 포함됨
      */
     public List<ErrorLogResponseDTO> getErrorsByUserId(Long userId) {
-        List<String> traceIds = apiPerformanceLogRepository.findTraceIdsByUserId(userId);
-
-        if (traceIds.isEmpty()) {
-            return List.of();
-        }
-
-        List<ErrorLogEntity> errorLogs = errorLogRepository.findByTraceIdIn(traceIds);
-        return errorLogs.stream()
+        return errorLogRepository.findByUserIdOrderByCreatedAtDesc(userId).stream()
                 .map(ErrorLogResponseDTO::fromList)
                 .toList();
     }

--- a/src/main/java/com/wanted/cookielms/global/config/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/wanted/cookielms/global/config/security/handler/CustomAccessDeniedHandler.java
@@ -46,6 +46,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
                 .clientIp(getClientIp(request))
                 .stackTrace("Security Filter Level: Access Denied")
                 .traceId(traceId)
+                .userId(getCurrentUserId())
                 .severity(globalErrorCode.getSeverity())
                 .build();
 

--- a/src/main/java/com/wanted/cookielms/global/error/handler/WebGlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/cookielms/global/error/handler/WebGlobalExceptionHandler.java
@@ -175,9 +175,8 @@ public class WebGlobalExceptionHandler {
                     .clientIp(getClientIp(request))
                     .stackTrace(getStackTraceAsString(e))
                     .traceId(traceId)
+                    .userId(getCurrentUserId())
                     .severity(severity)
-                    // 필요하다면 아래 줄의 주석을 풀고 userId를 저장할 수도 있습니다.
-                    // .userId(getCurrentUserId())
                     .build();
 
             errorLogService.saveErrorLogAsync(errorLog);

--- a/src/main/java/com/wanted/cookielms/global/logging/error/dto/ErrorLogResponseDTO.java
+++ b/src/main/java/com/wanted/cookielms/global/logging/error/dto/ErrorLogResponseDTO.java
@@ -22,6 +22,7 @@ public class ErrorLogResponseDTO {
     private String clientIp;
     private String stackTrace;
     private String traceId;
+    private Long userId;
     private ErrorSeverity severity;
     private LocalDateTime createdAt;
 
@@ -37,6 +38,7 @@ public class ErrorLogResponseDTO {
                 .clientIp(errorLog.getClientIp())
                 .stackTrace(errorLog.getStackTrace())
                 .traceId(errorLog.getTraceId())
+                .userId(errorLog.getUserId())
                 .severity(errorLog.getSeverity())
                 .createdAt(errorLog.getCreatedAt())
                 .build();

--- a/src/main/java/com/wanted/cookielms/global/logging/error/entity/ErrorLogEntity.java
+++ b/src/main/java/com/wanted/cookielms/global/logging/error/entity/ErrorLogEntity.java
@@ -13,7 +13,9 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "error_logs", indexes = {
-        @Index(name = "idx_trace_id", columnList = "traceId")
+        @Index(name = "idx_error_log_trace_id", columnList = "traceId"),
+        @Index(name = "idx_error_log_user_id", columnList = "userId"),
+        @Index(name = "idx_error_log_severity", columnList = "severity")
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -42,6 +44,9 @@ public class ErrorLogEntity {
     @Column(length = 36)
     private String traceId;
 
+    @Column
+    private Long userId;
+
     @Enumerated(EnumType.STRING)
     @Column(length = 20)
     private ErrorSeverity severity;
@@ -52,13 +57,15 @@ public class ErrorLogEntity {
 
     @Builder
     public ErrorLogEntity(String errorCode, String errorMessage, String exceptionName,
-                          String clientIp, String stackTrace, String traceId, ErrorSeverity severity) {
+                          String clientIp, String stackTrace, String traceId,
+                          Long userId, ErrorSeverity severity) {
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
         this.exceptionName = exceptionName;
         this.clientIp = clientIp;
         this.stackTrace = stackTrace;
         this.traceId = traceId;
+        this.userId = userId;
         this.severity = severity;
     }
 }

--- a/src/main/java/com/wanted/cookielms/global/logging/error/repository/ErrorLogRepository.java
+++ b/src/main/java/com/wanted/cookielms/global/logging/error/repository/ErrorLogRepository.java
@@ -69,31 +69,36 @@ public interface ErrorLogRepository extends JpaRepository<ErrorLogEntity, Long> 
     List<ErrorLogEntity> findByTraceIdIn(@Param("traceIds") List<String> traceIds);
 
     /**
-     * 사용자별 CRITICAL 에러 건수 집계 (API 로그 join)
-     * API 로그 테이블의 user_id를 기준으로 그룹핑
+     * 특정 사용자의 에러 로그 (user_id 직접 조회)
+     */
+    List<ErrorLogEntity> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    /**
+     * 사용자별 CRITICAL 에러 건수 집계
+     * error_logs.user_id를 기준으로 직접 그룹핑 (Security 필터 차단 요청 포함)
+     * 익명 요청(user_id IS NULL)은 제외
      */
     @Query(value = """
-    SELECT a.user_id as userId, u.id as loginId, COUNT(*) as errorCount
+    SELECT e.user_id as userId, u.id as loginId, COUNT(*) as errorCount
     FROM error_logs e
-    JOIN api_performance_logs a ON e.trace_id = a.trace_id
-    LEFT JOIN users u ON a.user_id = u.user_Id
+    LEFT JOIN users u ON e.user_id = u.user_Id
     WHERE e.severity = 'CRITICAL'
-    GROUP BY a.user_id, u.id
+      AND e.user_id IS NOT NULL
+    GROUP BY e.user_id, u.id
     ORDER BY errorCount DESC
 """, nativeQuery = true)
     List<Map<String, Object>> findCriticalErrorCountGroupByUserId();
 
     @Query("""
         SELECT new com.wanted.cookielms.domain.admin.dto.InsightErrorUserDto(
-            a.userId, u.loginId, COUNT(e), MAX(e.createdAt)
+            e.userId, u.loginId, COUNT(e), MAX(e.createdAt)
         )
         FROM ErrorLogEntity e
-        LEFT JOIN ApiPerformanceLogEntity a ON e.traceId = a.traceId
-        LEFT JOIN User u ON a.userId = u.userId
+        LEFT JOIN User u ON e.userId = u.userId
         WHERE e.severity = 'CRITICAL'
         AND e.createdAt >= :since
-        AND a.userId IS NOT NULL
-        GROUP BY a.userId, u.loginId
+        AND e.userId IS NOT NULL
+        GROUP BY e.userId, u.loginId
         HAVING COUNT(e) >= :threshold
         ORDER BY COUNT(e) DESC
         """)

--- a/src/main/resources/sql/reset_all_tables.sql
+++ b/src/main/resources/sql/reset_all_tables.sql
@@ -121,12 +121,14 @@ CREATE TABLE api_performance_logs (
     http_method         ENUM('GET','POST','PUT','DELETE')        NOT NULL,
     status_code         INT                                     NOT NULL,
     execution_time_ms   INT                                     NOT NULL,
-    client_ip           VARCHAR(255)                            NULL,
+    trace_id            VARCHAR(36)                             NULL,
     created_at          DATETIME                                NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (log_id),
     CONSTRAINT api_performance_logs_ibfk_1 FOREIGN KEY (user_id) REFERENCES users (user_id),
-    INDEX idx_endpoint   (endpoint),
-    INDEX idx_created_at (created_at)
+    INDEX idx_api_log_endpoint   (endpoint),
+    INDEX idx_api_log_created_at (created_at),
+    INDEX idx_api_log_user_id    (user_id),
+    INDEX idx_api_log_trace_id   (trace_id)
 );
 
 CREATE TABLE business_service_logs (
@@ -135,10 +137,7 @@ CREATE TABLE business_service_logs (
     created_at          DATETIME(6)     NOT NULL,
     execution_time_ms   BIGINT          NOT NULL,
     is_success          BIT(1)          NOT NULL,
-    method_name         VARCHAR(100)    NOT NULL,
-    service_name        VARCHAR(100)    NOT NULL,
     trace_id            VARCHAR(36)     NULL,
-    user_id             BIGINT          NULL,
     PRIMARY KEY (id),
     INDEX idx_class_method (class_method),
     INDEX idx_created_at   (created_at),
@@ -156,8 +155,11 @@ CREATE TABLE error_logs (
     severity        ENUM('CRITICAL','INFO','WARNING')   NULL,
     stack_trace     TEXT                                NULL,
     trace_id        VARCHAR(36)                         NULL,
+    user_id         BIGINT                              NULL,
     PRIMARY KEY (id),
-    INDEX idx_trace_id (trace_id)
+    INDEX idx_error_log_trace_id (trace_id),
+    INDEX idx_error_log_user_id  (user_id),
+    INDEX idx_error_log_severity (severity)
 );
 
 SET FOREIGN_KEY_CHECKS = 1;

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -215,8 +215,9 @@
 <!-- 모달: 유저 상세 -->
 <div id="userModal" class="modal-overlay" onclick="closeModal('userModal', event)">
     <div class="modal">
-        <div class="modal-header">
-            <h3 id="userModalTitle">유저 상세</h3>
+        <div class="modal-header" style="display:flex; align-items:center; gap:8px;">
+            <h3 id="userModalTitle" style="flex:1; margin:0;">유저 상세</h3>
+            <div id="userModalActions" style="display:flex; gap:8px;"></div>
             <button class="modal-close" onclick="closeModalById('userModal')">✕</button>
         </div>
         <div class="modal-body" id="userModalBody"><div class="loading">불러오는 중...</div></div>
@@ -449,11 +450,18 @@
         let html = '<table class="data-table"><thead><tr><th>사용자</th><th>에러 수</th><th>상세</th></tr></thead><tbody>';
 
         data.forEach(err => {
-            const userBtn = `<button class="link-btn" onclick="openUserErrorsModal(${err.userId}, '${err.loginId}')">${err.loginId}</button>`;
+            const hasUser = err.userId != null;
+            const label = err.loginId || '(미식별)';
+            const userCell = hasUser
+                ? `<button class="link-btn" onclick="openUserErrorsModal(${err.userId}, '${label}')">${label}</button>`
+                : `<span style="color:var(--text-muted);">${label}</span>`;
+            const detailCell = hasUser
+                ? `<button class="link-btn" onclick="openUserErrorsModal(${err.userId}, '${label}')">보기</button>`
+                : `<span style="color:var(--text-muted);">-</span>`;
             html += `<tr>
-            <td>${userBtn}</td>
+            <td>${userCell}</td>
             <td><span class="badge badge-danger">${err.errorCount}</span></td>
-            <td><button class="link-btn" onclick="openUserErrorsModal(${err.userId}, '${err.loginId}')">보기</button></td>
+            <td>${detailCell}</td>
         </tr>`;
         });
 
@@ -710,28 +718,18 @@
 
     // ── 사용자별 CRITICAL 에러 상세 모달 ──────────────────────
     function openUserErrorsModal(userId, loginId) {
+        if (userId == null) {
+            return;
+        }
+
         document.getElementById('userModalTitle').textContent = `${loginId} - CRITICAL 에러`;
 
-        // 밴 버튼 추가
-        const modalHeader = document.querySelector('#userModal .modal-header');
-        const existingBtn = modalHeader.querySelector('.ban-btn');
-        if (!existingBtn) {
-            const banBtn = document.createElement('button');
-            banBtn.className = 'action-btn ban-btn';
-            banBtn.style.marginRight = '10px';
-            banBtn.textContent = '밴';
-            banBtn.onclick = function() { banUser(userId); closeModalById('userModal'); };
-
-            const unbanBtn = document.createElement('button');
-            unbanBtn.className = 'action-btn unban-btn';
-            unbanBtn.style.marginRight = '10px';
-            unbanBtn.textContent = '밴 해제';
-            unbanBtn.onclick = function() { unbanUser(userId); closeModalById('userModal'); };
-
-            const closeBtn = modalHeader.querySelector('.modal-close');
-            modalHeader.insertBefore(unbanBtn, closeBtn);
-            modalHeader.insertBefore(banBtn, closeBtn);
-        }
+        // 액션 버튼(밴 / 밴 해제) 우측 상단 컨테이너에 렌더
+        const actions = document.getElementById('userModalActions');
+        actions.innerHTML = `
+            <button class="action-btn unban-btn" onclick="unbanUser(${userId}); closeModalById('userModal');">밴 해제</button>
+            <button class="action-btn ban-btn" onclick="banUser(${userId}); closeModalById('userModal');">밴</button>
+        `;
 
         document.getElementById('userModal').classList.add('active');
         const body = document.getElementById('userModalBody');


### PR DESCRIPTION
📝 작업한 내용
백엔드
error_logs 테이블에 user_id 컬럼 추가
Security 필터 차단(403) 에러의 유저 식별 가능
ErrorLogEntity에 userId 필드 추가 + 빌더 반영
error_logs 저장 시 userId 자동 주입
WebGlobalExceptionHandler.saveErrorLog — SecurityContext에서 userId 추출 활성화
CustomAccessDeniedHandler.handle — 403 차단 시 userId 저장 (핵심)
에러 로그 조회 로직 리팩토링
ErrorLogRepository 네이티브 쿼리: api_performance_logs JOIN 제거, error_logs.user_id 직접 사용
쿼리 단순화 + 성능 향상
ErrorLogQueryService.getErrorsByUserId: ApiPerformanceLogRepository 의존성 제거
ErrorLogRepository.findByUserIdOrderByCreatedAtDesc 신규 메서드 추가
에러 인사이트 쿼리 개선
findCriticalErrorUsersByTime JPQL도 api_performance_logs 우회, e.userId 기반으로 변경
프론트엔드
모달 레이아웃 개선
모달 헤더를 flexbox로 재구성: 제목(좌) / 액션버튼(우측 상단) / 닫기
밴/밴해제 버튼을 전용 컨테이너 #userModalActions에 렌더링
DOM 조작 방식 → 선언적 렌더링으로 변경
대시보드 에러 목록 null 방어
userId가 null인 행(미식별 사용자)은 텍스트로만 표시
버튼 미렌더링으로 openUserErrorsModal(null) 호출 방지
(미식별) 라벨로 구분
스키마
reset_all_tables.sql 반영
error_logs.user_id BIGINT NULL 추가
인덱스 3개 추가: idx_error_log_user_id, idx_error_log_severity, idx_error_log_trace_id 리네이밍
🖥️ 구현한 내용 시연 방법
앱 재시작
./gradlew bootRun
ddl-auto=update가 error_logs 스키마 자동 반영
CRITICAL 에러 생성 (403 Forbidden)
로그인한 사용자로 관리자 권한 없는 endpoint /admin/** 접근
예: /admin/logs/errors (학생 계정으로 접근)
Spring Security가 접근 거부 (AccessDeniedException)
대시보드 확인
/admin 대시보드 방문
"CRITICAL 에러" 섹션 → 403을 낸 유저가 "사용자"에 표시됨 (이전엔 "null")
"보기" 버튼 클릭 → 유저별 CRITICAL 에러 상세 모달 열림
모달 우측 상단에 "밴 해제", "밴" 버튼 정렬
에러 목록이 정상 로드됨 (이전엔 "데이터를 불러올 수 없습니다")
테스트 케이스
✓ 403 Forbidden (권한 없음): userId 저장 + 대시보드에 노출
✓ 401 Unauthorized (미인증): userId = null, 대시보드에 "(미식별)" 표시
✓ 컨트롤러 에러 (기존): 여전히 정상 동작