### PR TITLE
[Fix] 수강 신청 오류 처리 시스템 개선

### DIFF
--- a/src/main/java/com/wanted/cookielms/domain/enrollment/exception/EnrollmentErrorCode.java
+++ b/src/main/java/com/wanted/cookielms/domain/enrollment/exception/EnrollmentErrorCode.java
@@ -12,7 +12,7 @@ public enum EnrollmentErrorCode implements ErrorCode {
 
     ALREADY_ENROLLED(HttpStatus.CONFLICT, "ENR001", "이미 수강 신청한 강의입니다.", ErrorSeverity.INFO),
     LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, "ENR002", "존재하지 않는 강의입니다.", ErrorSeverity.WARNING),
-    ENROLLMENT_CAPACITY_EXCEEDED(HttpStatus.CONFLICT, "ENR003", "수강 정원이 초과되었습니다.", ErrorSeverity.WARNING),
+    ENROLLMENT_CAPACITY_EXCEEDED(HttpStatus.CONFLICT, "ENR003", "수강 정원이 초과되었습니다.", ErrorSeverity.CRITICAL),
     ENROLLMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ENR004", "수강 신청 내역을 찾을 수 없습니다.", ErrorSeverity.WARNING),
     ALREADY_WAITLISTED(HttpStatus.CONFLICT, "ENR005", "이미 대기열에 등록되어 있습니다.", ErrorSeverity.INFO),
     WAITLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "ENR006", "대기열 정보를 찾을 수 없습니다.", ErrorSeverity.CRITICAL);

--- a/src/main/java/com/wanted/cookielms/domain/enrollment/exception/EnrollmentException.java
+++ b/src/main/java/com/wanted/cookielms/domain/enrollment/exception/EnrollmentException.java
@@ -1,10 +1,14 @@
 package com.wanted.cookielms.domain.enrollment.exception;
 
-import com.wanted.cookielms.global.error.handler.ApplicationException;
+import com.wanted.cookielms.global.error.handler.AlertException;
 
-public class EnrollmentException extends ApplicationException {
+public class EnrollmentException extends AlertException {
 
     public EnrollmentException(EnrollmentErrorCode errorCode) {
-        super(errorCode.getStatus(), errorCode.getCode(), errorCode.getMessage(), errorCode.getSeverity());
+        super(errorCode);
+    }
+
+    public EnrollmentException(EnrollmentErrorCode errorCode, String redirectUrl) {
+        super(errorCode, redirectUrl);
     }
 }

--- a/src/main/java/com/wanted/cookielms/global/aop/FileValidation/FileValidationException.java
+++ b/src/main/java/com/wanted/cookielms/global/aop/FileValidation/FileValidationException.java
@@ -2,47 +2,24 @@ package com.wanted.cookielms.global.aop.FileValidation;
 
 import com.wanted.cookielms.global.error.handler.ApplicationException;
 import com.wanted.cookielms.global.error.handler.ErrorCode;
-import com.wanted.cookielms.global.logging.error.entity.enums.ErrorSeverity;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 public class FileValidationException extends ApplicationException {
 
     private final String redirectUrl; // null이면 history.back() 동작
 
-    // =================================================================
-    // 1. 문자열(String) 기반 생성자 (기존 유지 - 빠른 하드코딩용)
-    // =================================================================
-
-    // =================================================================
-    // 2. 🌟 ErrorCode 인터페이스 기반 생성자 (다형성 적용)
-    // 어떠한 도메인의 Enum(GlobalErrorCode, FileValidationErrorCode 등)도 모두 받을 수 있음
-    // =================================================================
-
-    /**
-     * Enum 지정 생성자: 알림 띄우고 이전 페이지로 돌아가기
-     */
     public FileValidationException(ErrorCode errorCode) {
-        super(errorCode); // ApplicationException의 ErrorCode 생성자 호출
+        super(errorCode);
         this.redirectUrl = null;
     }
 
-    /**
-     * Enum + URL 지정 생성자: 알림 띄우고 특정 페이지로 이동하기
-     */
     public FileValidationException(ErrorCode errorCode, String redirectUrl) {
         super(errorCode);
         this.redirectUrl = redirectUrl;
     }
 
-    /**
-     * Enum + 동적 메시지 + URL 지정 생성자:
-     * Enum의 기본 메시지 대신 변수가 포함된 커스텀 메시지를 사용하고 싶을 때
-     * (예: "[파일명.jpg]은 지원하지 않는 파일입니다.")
-     */
     public FileValidationException(ErrorCode errorCode, String customMessage, String redirectUrl) {
-        // 부모의 기본 생성자(상태, 코드, 메시지, 심각도)를 직접 호출하여 메시지만 바꿔치기
         super(errorCode.getStatus(), errorCode.getCode(), customMessage, errorCode.getSeverity());
         this.redirectUrl = redirectUrl;
     }

--- a/src/main/java/com/wanted/cookielms/global/error/handler/AlertException.java
+++ b/src/main/java/com/wanted/cookielms/global/error/handler/AlertException.java
@@ -1,0 +1,16 @@
+package com.wanted.cookielms.global.error.handler;
+
+/**
+ * alert 메시지로 던지고 ErrorLog에 기록되는 예외.
+ * 핸들러는 메시지 텍스트만 응답 body로 반환한다.
+ */
+public class AlertException extends ApplicationException {
+
+    public AlertException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AlertException(ErrorCode errorCode, String customMessage) {
+        super(errorCode.getStatus(), errorCode.getCode(), customMessage, errorCode.getSeverity());
+    }
+}

--- a/src/main/java/com/wanted/cookielms/global/error/handler/WebGlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/cookielms/global/error/handler/WebGlobalExceptionHandler.java
@@ -127,21 +127,34 @@ public class WebGlobalExceptionHandler {
     /**
      * [5] 🌟 UX를 고려한 전역 Alert 예외 처리 (수정됨)
      */
+    /**
+     * [5] AlertException - 메시지 텍스트만 응답, DB에 에러 로그 저장
+     */
+    @ExceptionHandler(AlertException.class)
+    public ResponseEntity<String> handleAlertException(AlertException e, HttpServletRequest request) {
+        String traceId = generateTraceId();
+        saveErrorLog(e, e.getCode(), e.getMessage(), request, traceId, e.getSeverity());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_TYPE, "text/plain; charset=UTF-8");
+        return new ResponseEntity<>(e.getMessage(), headers, e.getStatus());
+    }
+
+    /**
+     * [6] FileValidationException - script + redirect 방식 유지
+     */
     @ExceptionHandler(FileValidationException.class)
-    public ResponseEntity<String> handleAlertException(FileValidationException e, HttpServletRequest request) {
+    public ResponseEntity<String> handleFileValidationException(FileValidationException e, HttpServletRequest request) {
 
         String traceId = generateTraceId();
         saveErrorLog(e, e.getCode(), e.getMessage(), request, traceId, e.getSeverity());
 
-        // 2. 스크립트 생성 (작은따옴표 이스케이프 처리)
         String safeMessage = e.getMessage() != null ? e.getMessage().replace("'", "\\'") : "오류가 발생했습니다.";
         String script;
 
         if (e.getRedirectUrl() == null) {
-            // URL이 없으면 이전 폼으로 복귀 (입력 데이터 보존)
             script = String.format("<script>alert('%s'); history.back();</script>", safeMessage);
         } else {
-            // URL이 있으면 해당 페이지로 강제 이동
             script = String.format("<script>alert('%s'); location.href='%s';</script>", safeMessage, e.getRedirectUrl());
         }
 

--- a/src/main/resources/templates/user/enrollments.html
+++ b/src/main/resources/templates/user/enrollments.html
@@ -195,8 +195,10 @@
     }
 
     function enroll(id) {
-        fetch(`/api/enrollments/${id}`, {method:'POST'}).then(r => r.text()).then(msg => {
+        fetch(`/api/enrollments/${id}`, {method:'POST'}).then(async r => {
+            const msg = await r.text();
             alert(msg);
+            if (!r.ok) return;
             fetch('/api/enrollments/my').then(r => r.json()).then(ids => { myEnrolledIds = ids; loadLectures(currentKeyword, currentPage); });
         }).catch(() => alert('서버 오류가 발생했습니다.'));
     }


### PR DESCRIPTION
## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- 수강 신청 오류 처리 시스템 개선

---

## 📝 작업한 내용

### AlertException 시스템 도입
- `global/error/handler/AlertException` 신설: alert로 띄우면서 ErrorLog 자동 저장
- 메시지 텍스트만 응답하고 DB에 로그 기록하는 통합 예외 클래스

### 도메인 예외 통합
- `EnrollmentException` → `AlertException` 상속으로 전환
  - 정원초과(`ENROLLMENT_CAPACITY_EXCEEDED`) 시 alert + ErrorLog 자동 저장
- `FileValidationException` → 기존 script+redirect 방식 유지 (form submit용)
  - `ApplicationException` 직접 상속으로 분리

### 전역 예외 핸들러 분화
- `@ExceptionHandler(AlertException.class)`: plain text 메시지 + 상태코드 응답
- `@ExceptionHandler(FileValidationException.class)`: 기존 script(alert + redirect) 반환

### 프론트엔드 개선
- `enrollments.html` enroll() 함수: `!r.ok` 분기 추가
  - 실패 시 alert(메시지) 후 페이지 새로고침 스킵

### 로그 최적화
- `application.yaml`: Hibernate SQL/binding 로그 level `off` 설정
  - `show-sql: false`, `org.hibernate.SQL/bind: off`

---

## 🖥️ 구현한 내용 시연 방법

1. 강의 수강신청 페이지(`/user/enrollments`) 접속
2. 정원이 찬 강의의 "수강 신청" 버튼 클릭
3. "수강 정원이 초과되었습니다." alert 표시 확인
4. ErrorLog 조회(`/admin/logs`) → trace_id로 검색하여 로그 기록 확인
5. 파일 업로드 페이지에서 용량초과 파일 제출 → script 기반 alert + history.back() 동작 확인

---

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했습니다
- [x] 불필요한 주석 및 콘솔 로그를 제거했습니다
- [x] 기존 FileValidation 동작 호환성 유지